### PR TITLE
Prepare full run on server

### DIFF
--- a/src/test_cadet_core/crystallization.py
+++ b/src/test_cadet_core/crystallization.py
@@ -576,8 +576,8 @@ def crystallization_tests(n_jobs, database_path, small_test,
     # This is a special case, we have Nx and Ncol
     # Here we test EOC long each coordinate
     
-    N_x_ref   = 120 if small_test else 500 + 2
-    N_col_ref = 120 if small_test else 500
+    N_x_ref   = 120 if small_test else 200 + 2 # very fine reference: 500 + 2
+    N_col_ref = 120 if small_test else 200 # very fine reference: 500
     
     x_max = 900e-6 # um
     
@@ -599,7 +599,7 @@ def crystallization_tests(n_jobs, database_path, small_test,
     
     ## EOC, Nx
     
-    N_x_test_c6 = [20, 40, 80, ] if small_test else [25, 50, 100, 200, 400, ]
+    N_x_test_c6 = [20, 40, 80, ] if small_test else [20, 40, 80, 160, ] # very fine grid: [25, 50, 100, 200, 400, ]
     N_x_test_c6 = np.asarray(N_x_test_c6) + 2
     
     n_xs = []   ## store the result nx here
@@ -625,7 +625,7 @@ def crystallization_tests(n_jobs, database_path, small_test,
     
     ## EOC, Ncol
     
-    N_col_test_c6 = [20, 40, 80, ] if small_test else [25, 50, 100, 200, 400, ]   ## grid for EOC
+    N_col_test_c6 = [20, 40, 80, ] if small_test else [20, 40, 80, 160, ] # very fine grid: [25, 50, 100, 200, 400, ]   ## grid for EOC
     N_col_test_c6 = np.asarray(N_col_test_c6)
     
     n_xs = []   ## store the result nx here

--- a/src/test_cadet_core/utility/convergence.py
+++ b/src/test_cadet_core/utility/convergence.py
@@ -22,6 +22,34 @@ import os
 import h5py
 import shutil
 from colorama import Fore
+import platform
+from pathlib import Path
+
+def get_cadet_path():
+    install_path = None
+    
+    executable = 'cadet-cli'
+    if install_path is None:
+        try:
+            if platform.system() == 'Windows':
+                executable += '.exe'
+            executable_path = Path(shutil.which(executable))
+        except TypeError:
+            raise FileNotFoundError(
+                "CADET could not be found. Please set an install path"
+            )
+        install_path = executable_path.parent.parent
+    
+    install_path = Path(install_path)
+    cadet_bin_path = install_path / "bin" / executable
+    
+    if cadet_bin_path.exists():
+        return cadet_bin_path
+        
+    else:
+        raise FileNotFoundError(
+            "CADET could not be found. Please check the path"
+        )
 
 _DG_models_ = [
     "GENERAL_RATE_MODEL",

--- a/src/test_cadet_core/verify_cadet-core.py
+++ b/src/test_cadet_core/verify_cadet-core.py
@@ -52,8 +52,8 @@ sys.path.append(str(Path(".")))
 project_repo = ProjectRepo()
 output_path = project_repo.output_path / "test_cadet-core"
 
-# Specify a source build cadet_path and make sure the commit hash is visible
-cadet_path = r"C:\Users\jmbr\OneDrive\Desktop\CADET_compiled\master7_preV5Commit_21c653\aRELEASE\bin\cadet-cli.exe"
+# The get_cadet_path function searches for the cadet-cli. If you want to use a specific source build, please define the full path below
+cadet_path = convergence.get_cadet_path()
  
 
 # %% Run with CADET-RDM


### PR DESCRIPTION
This PR reduces the discretization refinement steps for crystallization since the desired convergence already shows for the first couple of steps and the finer discretizations require substantial computational resources.

Also, now that version 5 of cadet-core was released, we use the cadet python package cadet-cli instead of a local source build.

With these changes, we prepare a full rerun of the tests.