### PR TITLE
Update to CADET-Python v1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,5 @@ dependencies:
       - pandas
       - h5py
       - joblib
-      - cadet-python=0.14.1
+      - cadet-python
       - cadet-rdm

--- a/src/test_cadet_core/bench_func.py
+++ b/src/test_cadet_core/bench_func.py
@@ -72,11 +72,11 @@ def run_simulation(model, cadet_path):
         Cadet.cadet_path = cadet_path
     model[0].save()
     data = model[0].run()
-    if not data.returncode == 0:
+    if not data.return_code == 0:
         #     (f"simulation completed successfully")
         #     model.load()
         # else:
-        print(data)
+        print(data.error_message)
         raise Exception(f"simulation failed")
 
 

--- a/src/test_cadet_core/bench_func.py
+++ b/src/test_cadet_core/bench_func.py
@@ -607,8 +607,9 @@ def run_convergence_analysis_from_configs(
         backend(delayed(run_simulation)(sim, cadet_path)
                 for sim in zip(sims))
 
-        commit_hash = convergence.get_simulation(
-            sims[0].filename).root.meta['cadet_commit'].decode('utf-8')
+        commit_hash = convergence.get_commit_hash(
+            convergence.get_simulation(sims[0].filename)
+            )
 
     return run_convergence_analysis_core(
         commit_hash=commit_hash,
@@ -758,8 +759,9 @@ def run_convergence_analysis_from_database(
         backend(delayed(run_simulation)(sim, cadet_path)
                 for sim in zip(sims))
 
-        commit_hash = convergence.get_simulation(
-            sims[0].filename).root.meta['cadet_commit'].decode('utf-8')
+        commit_hash = convergence.get_commit_hash(
+            convergence.get_simulation(sims[0].filename)
+            )
 
     return run_convergence_analysis_core(
         database_path=database_path,

--- a/src/test_cadet_core/utility/convergence.py
+++ b/src/test_cadet_core/utility/convergence.py
@@ -40,7 +40,7 @@ def get_cadet_path():
         install_path = executable_path.parent.parent
     
     install_path = Path(install_path)
-    cadet_bin_path = install_path / "bin" / executable
+    cadet_bin_path = install_path
     
     if cadet_bin_path.exists():
         return cadet_bin_path

--- a/src/test_cadet_core/utility/convergence.py
+++ b/src/test_cadet_core/utility/convergence.py
@@ -525,12 +525,14 @@ def get_commit_hash(simulation):
     np.array
         Solution vector.
     """
-    return np.squeeze(
-        sim_go_to(
-            get_simulation(simulation).root, ['meta',
-                                              'CADET_COMMIT']
-        )
-    )
+    
+    simRoot = get_simulation(simulation).root
+    commit_info = sim_go_to(simRoot, ['meta', 'cadet_commit']).decode('utf-8')
+    
+    if commit_info == 'GITDIR-NOTFOUND':
+        commit_info = 'v.' + sim_go_to(simRoot, ['meta', 'cadet_version']).decode('utf-8') + ' commit'
+    
+    return commit_info
 
 def get_compute_time(simulation):
     """Get compute time from simulation

--- a/src/test_cadet_core/verify_cadet-core.py
+++ b/src/test_cadet_core/verify_cadet-core.py
@@ -52,8 +52,8 @@ sys.path.append(str(Path(".")))
 project_repo = ProjectRepo()
 output_path = project_repo.output_path / "test_cadet-core"
 
-# The get_cadet_path function searches for the cadet-cli. If you want to use a specific source build, please define the full path below
-cadet_path = convergence.get_cadet_path()
+# The get_cadet_path function searches for the cadet-cli. If you want to use a specific source build, please define the path below
+cadet_path = convergence.get_cadet_path() # path to root folder of bin\cadet-cli 
  
 
 # %% Run with CADET-RDM


### PR DESCRIPTION
CADET-Python v1 breaks CADET-Verification. Parallelization was already fixed, but we still get errors when the cadet_path is provided