### PR TITLE
Add output remote info to .cadet-rdm-data.json

### DIFF
--- a/.cadet-rdm-data.json
+++ b/.cadet-rdm-data.json
@@ -8,6 +8,6 @@
     "output_folder_name": "output",
     "output_remotes": {
       "origin": "git@github.com:cadet/CADET-Verification-Output.git"
-    }}
+    }
   }
 }

--- a/.cadet-rdm-data.json
+++ b/.cadet-rdm-data.json
@@ -6,6 +6,8 @@
   "cadet_rdm_version": "0.0.40",
   "output_remotes": {
     "output_folder_name": "output",
-    "output_remotes": {}
+    "output_remotes": {
+      "origin": "git@github.com:cadet/CADET-Verification-Output.git"
+    }}
   }
 }


### PR DESCRIPTION
For CADET-RDM to use rdm pull we need to add a remote to the output repo in the .cadet-rdm-data.json

This should have happened automatically and I don't know why it did not.
