### PR TITLE
Add option to delete h5 files after convergence analysis

### DIFF
--- a/src/test_cadet_core/MCT.py
+++ b/src/test_cadet_core/MCT.py
@@ -16,6 +16,9 @@ from cadet import Cadet
 from cadetrdm import ProjectRepo
 
 import bench_func as bf
+import utility.convergence as convergence
+import matplotlib.pyplot as plt
+import re
 
 # %% Run with CADET-RDM
 
@@ -24,6 +27,9 @@ def MCT_tests(n_jobs, database_path, small_test,
 
     os.makedirs(output_path, exist_ok=True)
     
+    convergence.std_plot_prep(benchmark_plot=False, linewidth=10,
+                              x_label='time / s', y_label='mol / $m^{-3}$')
+    
     Cadet.cadet_path = cadet_path
     
     model = bf.create_object_from_database(
@@ -31,8 +37,11 @@ def MCT_tests(n_jobs, database_path, small_test,
         cadet_config_json_name='configuration_LRM_dynLin_1comp_MCTbenchmark.json',
         output_path=str(output_path)
         )
-    model.run()
+    data = model.run()
     model.load()
+    if not data.return_code == 0:
+        print(data.error_message)
+        raise Exception(f"simulation failed")
     model.save()
     
     model = bf.create_object_from_database(
@@ -40,8 +49,11 @@ def MCT_tests(n_jobs, database_path, small_test,
         cadet_config_json_name='configuration_LRM_noBnd_1comp_MCTbenchmark.json',
         output_path=str(output_path)
         )
-    model.run()
+    data = model.run()
     model.load()
+    if not data.return_code == 0:
+        print(data.error_message)
+        raise Exception(f"simulation failed")
     model.save()
     
     model = bf.create_object_from_database(
@@ -49,8 +61,20 @@ def MCT_tests(n_jobs, database_path, small_test,
         cadet_config_json_name='configuration_MCT1ch_noEx_noReac_benchmark1.json',
         output_path=str(output_path)
         )
-    model.run()
+    data = model.run()
     model.load()
+    if not data.return_code == 0:
+        print(data.error_message)
+        raise Exception(f"simulation failed")
+    
+    sol_name = model.filename
+    time = convergence.get_solution_times(sol_name)
+    channel1 = convergence.get_solution(sol_name, unit='unit_001', which='outlet_port_000')
+
+    plt.plot(time, channel1, label='channel 1')
+    plt.legend(fontsize=20)
+    plt.savefig(re.sub(".h5", ".png", sol_name), dpi=100, bbox_inches='tight')
+    
     model.save()
     
     model = bf.create_object_from_database(
@@ -58,8 +82,20 @@ def MCT_tests(n_jobs, database_path, small_test,
         cadet_config_json_name='configuration_MCT1ch_noEx_reac_benchmark1.json',
         output_path=str(output_path)
         )
-    model.run()
+    data = model.run()
     model.load()
+    if not data.return_code == 0:
+        print(data.error_message)
+        raise Exception(f"simulation failed")
+    
+    sol_name = model.filename
+    time = convergence.get_solution_times(sol_name)
+    channel1 = convergence.get_solution(sol_name, unit='unit_001', which='outlet_port_000')
+
+    plt.plot(time, channel1, label='channel 1')
+    plt.legend(fontsize=20)
+    plt.savefig(re.sub(".h5", ".png", sol_name), dpi=100, bbox_inches='tight')
+    
     model.save()
     
     model = bf.create_object_from_database(
@@ -67,8 +103,22 @@ def MCT_tests(n_jobs, database_path, small_test,
         cadet_config_json_name='configuration_MCT2ch_oneWayEx_reac_benchmark1.json',
         output_path=str(output_path)
         )
-    model.run()
+    data = model.run()
     model.load()
+    if not data.return_code == 0:
+        print(data.error_message)
+        raise Exception(f"simulation failed")
+    
+    sol_name = model.filename
+    time = convergence.get_solution_times(sol_name)
+    channel1 = convergence.get_solution(sol_name, unit='unit_001', which='outlet_port_000')
+    channel2 = convergence.get_solution(sol_name, unit='unit_001', which='outlet_port_001')
+
+    plt.plot(time, channel1, label='channel 1')
+    plt.plot(time, channel2, label='channel 2')
+    plt.legend(fontsize=20)
+    plt.savefig(re.sub(".h5", ".png", sol_name), dpi=100, bbox_inches='tight')
+    
     model.save()
     
     model = bf.create_object_from_database(
@@ -76,6 +126,23 @@ def MCT_tests(n_jobs, database_path, small_test,
         cadet_config_json_name='configuration_MCT3ch_twoWayExc_reac_benchmark1.json',
         output_path=str(output_path)
         )
-    model.run()
+    data = model.run()
     model.load()
+    if not data.return_code == 0:
+        print(data.error_message)
+        raise Exception(f"simulation failed")
+    
+    sol_name = model.filename
+    time = convergence.get_solution_times(sol_name)
+    channel1 = convergence.get_solution(sol_name, unit='unit_001', which='outlet_port_000')
+    channel2 = convergence.get_solution(sol_name, unit='unit_001', which='outlet_port_001')
+    channel3 = convergence.get_solution(sol_name, unit='unit_001', which='outlet_port_002')
+
+    plt.plot(time, channel1, label='channel 1')
+    plt.plot(time, channel2, label='channel 2')
+    plt.plot(time, channel3, label='channel 3')
+    plt.legend(fontsize=20)
+    plt.savefig(re.sub(".h5", ".png", sol_name), dpi=100, bbox_inches='tight')
+    
     model.save()
+    

--- a/src/test_cadet_core/utility/convergence.py
+++ b/src/test_cadet_core/utility/convergence.py
@@ -3346,6 +3346,50 @@ def mult_sim_rerun(file_path, cadet_path, n_wdh):
             print(file + " kein h5")
 
 
+def delete_h5_files(directory, exclude_files=None):
+    """
+    Deletes all .h5 files in the specified directory, excluding files whose names (without extension) 
+    are in the exclusion list.
+
+    Parameters:
+        directory (str): The path of the directory to clean up.
+        exclude_files (list, optional): List of file names (without extensions) to exclude from deletion.
+    """
+    if not os.path.exists(directory):
+        print(f"Directory {directory} does not exist.")
+        return
+
+    if not os.path.isdir(directory):
+        print(f"Provided path {directory} is not a directory.")
+        return
+
+    if exclude_files is None:
+        exclude_files = []
+
+    # Convert exclude_files to a set for fast lookup
+    exclude_set = set(exclude_files)
+    
+    deleted_files = 0
+    for filename in os.listdir(directory):
+        # Extract the base name (without extension)
+        base_name, ext = os.path.splitext(filename)
+        if ext == '.h5' and base_name not in exclude_set:
+            file_path = os.path.join(directory, filename)
+            try:
+                os.remove(file_path)
+                print(f"Deleted: {file_path}")
+                deleted_files += 1
+            except Exception as e:
+                print(f"Error deleting {file_path}: {e}")
+        elif base_name in exclude_set:
+            print(f"Skipping excluded file: {filename}")
+
+    if deleted_files == 0:
+        print("No .h5 files deleted in the directory.")
+    else:
+        print(f"Deleted {deleted_files} .h5 file(s).")
+
+
 if __name__ == '__main__':
 
     test_eoc()

--- a/src/test_cadet_core/utility/convergence.py
+++ b/src/test_cadet_core/utility/convergence.py
@@ -2802,8 +2802,7 @@ def std_plot(x_axis, y_axis, **kwargs):
             str(x_axis.ndim)
         )
 
-
-def std_plot_prep(**kwargs):
+def std_plot_prep(benchmark_plot=True, **kwargs):
     """Create standard plot setting.
 
     Parameters
@@ -2839,19 +2838,21 @@ def std_plot_prep(**kwargs):
         y_label = None
     if 'shape' in kwargs:
         shape = kwargs.pop('shape')
-    else:
+    elif benchmark_plot:
         shape = [20, 10]
+    else:
+        shape = [10, 10]
     if 'font_size_fac' in kwargs:
         font_size_factor = kwargs.pop('font_size_fac')
     else:
         font_size_factor = 1.5
     if 'x_scale' in kwargs:
         x_scale = kwargs.pop('x_scale')
-    else:
+    elif benchmark_plot:
         x_scale = 'log'
     if 'y_scale' in kwargs:
         y_scale = kwargs.pop('y_scale')
-    else:
+    elif benchmark_plot:
         y_scale = 'log'
     if 'x_lim' in kwargs:
         x_lim = kwargs['x_lim']
@@ -2871,19 +2872,21 @@ def std_plot_prep(**kwargs):
     # elif y_lim is not None:
     #     y_ticks = np.logspace(y_lim[0], y_lim[1], num=12, endpoint=True)
 
-    if 'linewidth' not in kwargs:
+    if 'linewidth' not in kwargs and benchmark_plot:
         kwargs['linewidth'] = 3
-    if 'marker' not in kwargs:
+    if 'marker' not in kwargs and benchmark_plot:
         kwargs['marker'] = 'o'
-    if 'markersize' not in kwargs:
+    if 'markersize' not in kwargs and benchmark_plot:
         kwargs['markersize'] = 12
 
     plt.rcParams["figure.figsize"] = (shape[0], shape[1])
 
     plt.legend(fontsize=15*font_size_factor)
     plt.grid()
-    plt.yscale(y_scale)
-    plt.xscale(x_scale)
+    if benchmark_plot or 'y_scale' in kwargs:
+        plt.yscale(y_scale)
+    if benchmark_plot or 'x_scale' in kwargs:
+        plt.xscale(x_scale)
     if x_label is not None:
         plt.xlabel(x_label, fontsize=15*font_size_factor)
     if x_label is not None:
@@ -3377,17 +3380,14 @@ def delete_h5_files(directory, exclude_files=None):
             file_path = os.path.join(directory, filename)
             try:
                 os.remove(file_path)
-                print(f"Deleted: {file_path}")
                 deleted_files += 1
             except Exception as e:
                 print(f"Error deleting {file_path}: {e}")
-        elif base_name in exclude_set:
-            print(f"Skipping excluded file: {filename}")
 
     if deleted_files == 0:
-        print("No .h5 files deleted in the directory.")
+        print("No .h5 files deleted in the {directory} directory.")
     else:
-        print(f"Deleted {deleted_files} .h5 file(s).")
+        print(f"Deleted {deleted_files} .h5 file(s) in the {directory} directory.")
 
 
 if __name__ == '__main__':

--- a/src/test_cadet_core/verify_cadet-core.py
+++ b/src/test_cadet_core/verify_cadet-core.py
@@ -41,6 +41,9 @@ small_test = False # Defines a smaller test set (less numerical refinement steps
 
 n_jobs = -1 # For parallelization on the number of simulations
 
+delete_h5_files = True # delete h5 files (but keep convergence tables and plots)
+exclude_files = None # ["file1", "file2"] # specify h5 files that should not be deleted
+
 run_chromatography_tests = True
 run_crystallization_tests = True
 run_MCT_tests = True
@@ -67,6 +70,9 @@ with project_repo.track_results(results_commit_message=commit_message, debug=rdm
             output_path=str(output_path) + "/chromatography", cadet_path=cadet_path
             )
     
+        if delete_h5_files:
+            convergence.delete_h5_files(str(output_path) + "/chromatography", exclude_files=exclude_files)
+        
     if run_crystallization_tests:
         crystallization.crystallization_tests(
             n_jobs=n_jobs, database_path=database_path+"crystallization/",
@@ -74,6 +80,9 @@ with project_repo.track_results(results_commit_message=commit_message, debug=rdm
             output_path=str(output_path) + "/crystallization", cadet_path=cadet_path
             )
     
+        if delete_h5_files:
+            convergence.delete_h5_files(str(output_path) + "/crystallization", exclude_files=exclude_files)
+        
     if run_MCT_tests:
         MCT.MCT_tests(
             n_jobs=n_jobs, database_path=database_path+"mct/",
@@ -81,3 +90,6 @@ with project_repo.track_results(results_commit_message=commit_message, debug=rdm
             output_path=str(output_path) + "/mct", cadet_path=cadet_path
             )
     
+        if delete_h5_files:
+            convergence.delete_h5_files(str(output_path) + "/mct", exclude_files=exclude_files)
+        


### PR DESCRIPTION
With an increasing number of tests, we should delete simulation files and only keep the convergence tables.
Optionally, we can specify simulation files that we want to keep, e.g. reference solutions.