### PR TITLE
Add multiple reaction test

### DIFF
--- a/src/multiple_reaction_configs.py
+++ b/src/multiple_reaction_configs.py
@@ -1,0 +1,438 @@
+import numpy as np
+
+def cstr_setup(model):
+
+    ncomp = 3
+    init_c = [1.0, 2.0, 3.0]
+    sim_time = 10.0
+
+    model.root.input.model.nunits = 1
+
+    # CSTR
+    model.root.input.model.unit_000.unit_type = 'CSTR'
+    model.root.input.model.unit_000.ncomp = ncomp
+    model.root.input.model.unit_000.init_liquid_volume = 1.0
+    model.root.input.model.unit_000.init_c = init_c
+    model.root.input.model.unit_000.const_solid_volume = 1.0
+    model.root.input.model.unit_000.use_analytic_jacobian = 0 # jacobian has a bug
+
+    #Configure solver settings
+    model.root.input.solver.user_solution_times = np.linspace(0, sim_time, 1000)
+    model.root.input.solver.sections.nsec = 1
+    model.root.input.solver.sections.section_times = [0.0, sim_time]
+    model.root.input.solver.sections.section_continuity = []
+
+    model.root.input.model.solver.gs_type = 1
+    model.root.input.model.solver.max_krylov = 0
+    model.root.input.model.solver.max_restarts = 10
+    model.root.input.model.solver.schur_safety = 1e-8
+
+    model.root.input.solver.time_integrator.abstol = 1e-6
+    model.root.input.solver.time_integrator.algtol = 1e-10
+    model.root.input.solver.time_integrator.reltol = 1e-6
+    model.root.input.solver.time_integrator.init_step_size = 1e-6
+    model.root.input.solver.time_integrator.max_steps = 1000000
+    model.root.input.solver.consistent_init_mode = 1
+
+    model.root.input['return'].split_components_data = 0
+    model.root.input['return'].split_ports_data = 0
+    model.root.input['return'].unit_000.write_solution_bulk = 1
+    model.root.input['return'].unit_000.write_solution_inlet = 1
+    model.root.input['return'].unit_000.write_solution_outlet = 1
+
+    # Connections
+    model.root.input.model.connections.nswitches = 1
+    model.root.input.model.connections.switch_000.section = 0
+    model.root.input.model.connections.switch_000.connections = [ ]
+
+    return model
+
+def lrmp_setup(model):
+    
+    ncomp = 3
+    init_c = [1.0, 2.0, 3.0]
+    init_q = init_c.copy()
+    sim_time = 10.0
+
+    model.root.input.model.nunits = 1
+
+    model.root.input.model.unit_000.unit_type = 'LUMPED_RATE_MODEL_WITH_PORES'
+    model.root.input.model.unit_000.ncomp = ncomp
+    model.root.input.model.unit_000.nbound = ncomp * [1.0]
+    model.root.input.model.unit_000.init_liquid_volume = 1.0
+    model.root.input.model.unit_000.init_c = init_c 
+    model.root.input.model.unit_000.init_q = init_q
+    model.root.input.model.unit_000.col_dispersion = 1e-5
+    model.root.input.model.unit_000.col_length  = 0.6
+    model.root.input.model.unit_000.col_porosity  = 0.37
+    model.root.input.model.unit_000.film_diffusion = [1e-5] * ncomp
+
+    model.root.input.model.unit_000.par_porosity = 0.33
+    model.root.input.model.unit_000.par_radius = 1e-6
+    model.root.input.model.unit_000.cross_section_area = 1.0386890710931253E-4
+
+    model.root.input.model.unit_000.discretization.ncol                  = 1
+    model.root.input.model.unit_000.discretization.use_analytic_jacobian = 1
+    model.root.input.model.unit_000.discretization.weno.boundary_model   = 0 
+    model.root.input.model.unit_000.discretization.weno.weno_eps         = 1e-10
+    model.root.input.model.unit_000.discretization.weno.weno_order       = 1
+    model.root.input.model.unit_000.discretization.max_restarts          = 10
+    model.root.input.model.unit_000.discretization.gs_type              = 1
+    model.root.input.model.unit_000.discretization.max_krylov           = 0
+    model.root.input.model.unit_000.discretization.schur_safety          = 1e-8
+    model.root.input.model.unit_000.discretization.reconstruction = 'WENO'
+    model.root.input.model.unit_000.discretization.par_disc_type = 'EQUIDISTANT_PAR'
+
+    # model.root.input.model.unit_000.reaction_model = 'MASS_ACTION_LAW'
+    # model.root.input.model.unit_000.reaction_bulk.mal_kfwd_bulk = [0.5]
+    # model.root.input.model.unit_000.reaction_bulk.mal_kbwd_bulk = [0.5]
+    # model.root.input.model.unit_000.reaction_bulk.mal_stoichiometry_bulk = [[-1],[1],[0]]
+
+    """Configure solver settings"""
+    model.root.input.solver.user_solution_times = np.linspace(0, sim_time, 1000)
+    model.root.input.solver.sections.nsec = 1
+    model.root.input.solver.sections.section_times = [0.0, sim_time]
+    model.root.input.solver.sections.section_continuity = 0
+
+    model.root.input.model.solver.gs_type = 1
+    model.root.input.model.solver.max_krylov = 0
+    model.root.input.model.solver.max_restarts = 10
+    model.root.input.model.solver.schur_safety = 1e-8
+
+    model.root.input.solver.time_integrator.abstol = 1e-6
+    model.root.input.solver.time_integrator.algtol = 1e-10
+    model.root.input.solver.time_integrator.reltol = 1e-6
+    model.root.input.solver.time_integrator.init_step_size = 1e-6
+    model.root.input.solver.time_integrator.max_steps = 1000000
+    model.root.input.solver.consistent_init_mode = 1
+
+    model.root.input.model.connections.nswitches = 1
+    model.root.input.model.connections.switch_000.section = 0
+    model.root.input.model.connections.switch_000.connections = []
+
+    model.root.input['return'].split_components_data = 0
+    model.root.input['return'].split_ports_data = 0
+    model.root.input['return'].unit_000.write_solution_bulk = 1
+    model.root.input['return'].unit_000.write_solution_inlet = 0
+    model.root.input['return'].unit_000.write_solution_outlet = 0
+    model.root.input['return'].unit_000.write_sens_outlet = 0
+
+    # Adsorption model -> have to be set
+    model.root.input.model.unit_000.adsorption_model = 'LINEAR'
+    model.root.input.model.unit_000.adsorption.is_kinetic  = True
+    model.root.input.model.unit_000.adsorption.lin_ka = [0,0,0]
+    model.root.input.model.unit_000.adsorption.lin_kd = [0,0,0]
+
+    return model
+
+def grm_setup(model):
+    
+    ncomp = 3
+    init_c = [1.0, 2.0, 3.0]
+    init_q = init_c.copy()
+
+    sim_time = 10.0
+
+    model.root.input.model.nunits = 1
+
+    # GRM
+    model.root.input.model.unit_000.unit_type = 'GENERAL_RATE_MODEL'
+    model.root.input.model.unit_000.ncomp = 3
+    model.root.input.model.unit_000.nbound = [1.0] * ncomp
+    model.root.input.model.unit_000.init_c = init_c 
+    model.root.input.model.unit_000.init_q = init_q
+
+    ## Geometry
+    model.root.input.model.unit_000.col_length = 0.1    #h5            # m
+    model.root.input.model.unit_000.col_porosity = 0.37 #h5            # -
+    model.root.input.model.unit_000.par_porosity = 0.33 #5            # -
+    model.root.input.model.unit_000.par_radius = 1e-6   #5            # m
+                                                                    
+    ## Transport
+    model.root.input.model.unit_000.col_dispersion = 1e-8   #h5
+    model.root.input.model.unit_000.col_dispersion_radial = 1e-6   #h5       # m^2 / s (interstitial volume)
+    model.root.input.model.unit_000.film_diffusion = [1e-5] *ncomp   #5     # m / s
+    model.root.input.model.unit_000.par_diffusion = [1e-10] *ncomp#h5       # m^2 / s (mobile phase)  
+    model.root.input.model.unit_000.par_surfdiffusion = [0.0]*ncomp  #h5    # m^2 / s (solid phase)
+    model.root.input.model.unit_000.par_coreradius = 0 #h5      # m^2 / s (solid phase)
+    model.root.input.model.unit_000.total_porosity = 0.84 #h5      # m^2 / s (solid phase)
+    model.root.input.model.unit_000.velocity = 5.75e-4 #h5      # m^2 / s (solid phase)
+
+    ## Discretization
+    ### Grid cells
+    model.root.input.model.unit_000.discretization.ncol                  = 1
+    model.root.input.model.unit_000.discretization.use_analytic_jacobian = 1
+    model.root.input.model.unit_000.discretization.weno.boundary_model   = 0 
+    model.root.input.model.unit_000.discretization.weno.weno_eps         = 1e-10
+    model.root.input.model.unit_000.discretization.weno.weno_order       = 1
+    model.root.input.model.unit_000.discretization.max_restarts          = 10
+    model.root.input.model.unit_000.discretization.gs_type              = 1
+    model.root.input.model.unit_000.discretization.max_krylov           = 0
+    model.root.input.model.unit_000.discretization.schur_safety          = 1e-8
+    model.root.input.model.unit_000.discretization.reconstruction = 'WENO'
+    model.root.input.model.unit_000.discretization.par_disc_type = 'EQUIDISTANT_PAR'
+    model.root.input.model.unit_000.discretization.npar = 1
+
+
+    # Return data
+    model.root.input['return'].split_components_data = 0
+    model.root.input['return'].split_ports_data = 0
+    model.root.input['return'].unit_000.write_solution_bulk = 1
+    model.root.input['return'].unit_000.write_solution_inlet = 1
+    model.root.input['return'].unit_000.write_solution_outlet = 1
+    model.root.input['return'].unit_000.write_sens_outlet = 1
+
+
+    """Configure solver settings"""
+    model.root.input.solver.user_solution_times = np.linspace(0, sim_time, 1000)
+    model.root.input.solver.sections.nsec = 1
+    model.root.input.solver.sections.section_times = [0.0, sim_time]
+    model.root.input.solver.sections.section_continuity = []
+
+    model.root.input.model.solver.gs_type = 1
+    model.root.input.model.solver.max_krylov = 0
+    model.root.input.model.solver.max_restarts = 10
+    model.root.input.model.solver.schur_safety = 1e-8
+
+    model.root.input.solver.time_integrator.abstol = 1e-6
+    model.root.input.solver.time_integrator.algtol = 1e-10
+    model.root.input.solver.time_integrator.reltol = 1e-6
+    model.root.input.solver.time_integrator.init_step_size = 1e-6
+    model.root.input.solver.time_integrator.max_steps = 1000000
+    model.root.input.solver.consistent_init_mode = 1
+
+
+    """Connect the units together"""
+    # Connections
+    model.root.input.model.connections.nswitches = 1
+    model.root.input.model.connections.switch_000.section = 0
+    model.root.input.model.connections.switch_000.connections = []
+
+     # Adsorption model -> have to be set
+    model.root.input.model.unit_000.adsorption_model = 'LINEAR'
+    model.root.input.model.unit_000.adsorption.is_kinetic  = True
+    model.root.input.model.unit_000.adsorption.lin_ka = [0,0,0]
+    model.root.input.model.unit_000.adsorption.lin_kd = [0,0,0]
+
+    return model
+
+def mal_setup_particle_old(model, reaction_dict):
+    
+    #Configure the reaction system
+    model.root.input.model.unit_000.reaction_model_particles = reaction_dict[f"reaction_type_000"]
+    model.root.input.model.unit_000.reaction_particle_000.mal_kfwd_liquid = [reaction_dict[f'kfwd_liquid_000']]
+    model.root.input.model.unit_000.reaction_particle_000.mal_kbwd_liquid = [reaction_dict[f'kbwd_liquid_000']]
+
+        # Stoichiometry matrix 2D array [components][reaction]
+    model.root.input.model.unit_000.reaction_particle_000.mal_stoichiometry_liquid = reaction_dict[f'stoichiometric_matrix_liquid_000']
+
+    model.root.input.model.unit_000.reaction_particle_000.mal_kfwd_solid = [reaction_dict[f'kfwd_solid_000']]
+    model.root.input.model.unit_000.reaction_particle_000.mal_kbwd_solid = [reaction_dict[f'kbwd_solid_000']]
+
+        # Stoichiometry matrix 2D array [components][reaction]
+    model.root.input.model.unit_000.reaction_particle_000.mal_stoichiometry_solid = reaction_dict[f'stoichiometric_matrix_solid_000']
+
+    return model
+
+def mal_setup_bulk_old(model, reaction_dict):
+    
+    #Configure the reaction system
+    model.root.input.model.unit_000.reaction_model = reaction_dict[f"reaction_type_000"]
+    model.root.input.model.unit_000.reaction_bulk.mal_kfwd_bulk = [reaction_dict[f'kfwd_000']]
+    model.root.input.model.unit_000.reaction_bulk.mal_kbwd_bulk = [reaction_dict[f'kbwd_000']]
+
+        # Stoichiometry matrix 2D array [components][reaction]
+    model.root.input.model.unit_000.reaction_bulk.mal_stoichiometry_bulk = reaction_dict[f'stoichiometric_matrix_000']
+
+    return model
+
+def mal_setup_bulk(model, reaction_dict):
+    
+    #Configure the reaction system
+    model.root.input.model.unit_000.reaction_bulk.nreac = reaction_dict['num_reactions']
+    for i in range(reaction_dict['num_reactions']):
+        getattr(model.root.input.model.unit_000.reaction_bulk, f"reaction_model_{i:03d}").reaction_type = reaction_dict[f"reaction_type_{i:03d}"]
+        getattr(model.root.input.model.unit_000.reaction_bulk, f"reaction_model_{i:03d}").mal_kfwd_bulk = [reaction_dict[f'kfwd_{i:03d}']]
+        getattr(model.root.input.model.unit_000.reaction_bulk, f"reaction_model_{i:03d}").mal_kbwd_bulk = [reaction_dict[f'kbwd_{i:03d}']]
+
+        # Stoichiometry matrix 2D array [components][reaction]
+        getattr(model.root.input.model.unit_000.reaction_bulk, f"reaction_model_{i:03d}").mal_stoichiometry_bulk = reaction_dict[f'stoichiometric_matrix_{i:03d}']
+
+    return model
+
+def mal_setup_cross_phase(model, reaction_dict):
+    
+    #Configure the reaction system
+
+    model.root.input.model.unit_000.reaction_model_particles = reaction_dict[f"reaction_type_000"]
+    model.root.input.model.unit_000.reaction_particle_000.mal_kfwd_liquid = [reaction_dict[f'kfwd_liquid_000']]
+    model.root.input.model.unit_000.reaction_particle_000.mal_kbwd_liquid = [reaction_dict[f'kbwd_liquid_000']]
+
+        # Stoichiometry matrix 2D array [components][reaction]
+    model.root.input.model.unit_000.reaction_particle_000.mal_stoichiometry_liquid = reaction_dict[f'stoichiometric_matrix_liquid_000']
+
+    model.root.input.model.unit_000.reaction_particle_000.mal_kfwd_solid = [reaction_dict[f'kfwd_solid_000']]
+    model.root.input.model.unit_000.reaction_particle_000.mal_kbwd_solid = [reaction_dict[f'kbwd_solid_000']]
+
+        # Stoichiometry matrix 2D array [components][reaction]
+    model.root.input.model.unit_000.reaction_particle_000.mal_stoichiometry_solid = reaction_dict[f'stoichiometric_matrix_solid_000']
+
+    return model
+
+def mal_setup_paricle(model, reaction_dict):
+    
+    #Configure the reaction system
+    model.root.input.model.unit_000.reaction_particle.nreac = reaction_dict['num_reactions']
+    for i in range(reaction_dict['num_reactions']):
+        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").reaction_type = reaction_dict[f"reaction_type_{i:03d}"]
+        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").mal_kfwd = [reaction_dict[f'kfwd_{i:03d}']]
+        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").mal_kbwd = [reaction_dict[f'kbwd_{i:03d}']]
+
+        # Stoichiometry matrix 2D array [components][reaction]
+        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").mal_stoichiometry = reaction_dict[f'stoichiometric_matrix_{i:03d}']
+
+    return model
+
+def get_dict_one_reaction_mal():
+    
+    return {
+    "num_reactions": 1, 
+    "reaction_type_000": "MASS_ACTION_LAW",
+    "stoichiometric_matrix_000": [[-1, -1, 0],
+                                [1, 1, -1],
+                                [1, 0, 1]],
+    "kfwd_000": [1.0, 0.5, 1.0],
+    "kbwd_000": [1.0, 0.3, 1.0]
+}
+
+def get_dict_two_reaction_mal():
+    
+    return  {
+    "num_reactions": 2, 
+    "reaction_type_000": "MASS_ACTION_LAW",
+    "stoichiometric_matrix_000": [[-1, -1],
+                                    [1, 1],
+                                    [1, 0]],
+    "kfwd_000": [1.0, 0.5],
+    "kbwd_000": [1.0, 0.3], 
+    "reaction_type_001": "MASS_ACTION_LAW",
+    "stoichiometric_matrix_001": [[0],
+                                [-1],
+                                [1]],
+    "kfwd_001": [1.0],
+    "kbwd_001": [1.0]
+
+    }
+
+def get_dict_three_reaction_mal():
+    return {
+    "num_reactions": 3,
+    "reaction_type_000": "MASS_ACTION_LAW",
+    "stoichiometric_matrix_000": [[-1], [1], [1]],
+    "kfwd_000": [1.0],
+    "kbwd_000": [1.0],
+    "reaction_type_001": "MASS_ACTION_LAW",
+    "stoichiometric_matrix_001": [[-1], [1], [0]],
+    "kfwd_001": [0.5],
+    "kbwd_001": [0.3],
+    "reaction_type_002": "MASS_ACTION_LAW",
+    "stoichiometric_matrix_002": [[0], [-1], [1]],
+    "kfwd_002": [1.0],
+    "kbwd_002": [1.0]
+    }
+
+def get_dict_one_reaction_cross_phase():
+    return {
+        "num_reactions": 1,
+        "reaction_type_000": "MASS_ACTION_LAW",
+        "kfwd_liquid_000": 1.0,
+        "kbwd_liquid_000": 1.0,
+        "stoichiometric_matrix_liquid_000": [[-1], [1], [0]],
+        "kfwd_solid_000": 0.5,
+        "kbwd_solid_000": 0.3,
+        "stoichiometric_matrix_solid_000": [[0], [0], [1]]
+    }
+
+def get_dict_two_reactions_cross_phase():
+    return {
+        "num_reactions": 2,
+        "reaction_type_000": "MASS_ACTION_LAW",
+        "kfwd_liquid_000": 1.0,
+        "kbwd_liquid_000": 1.0,
+        "stoichiometric_matrix_liquid_000": [[-1], [1], [0]],
+        "kfwd_solid_000": 0.5,
+        "kbwd_solid_000": 0.3,
+        "stoichiometric_matrix_solid_000": [[0], [0], [1]],
+        "reaction_type_001": "MASS_ACTION_LAW",
+        "kfwd_liquid_001": 0.8,
+        "kbwd_liquid_001": 0.4,
+        "stoichiometric_matrix_liquid_001": [[-1], [0], [1]],
+        "kfwd_solid_001": 0.6,
+        "kbwd_solid_001": 0.2,
+        "stoichiometric_matrix_solid_001": [[0], [1], [-1]]
+    }
+
+def get_dict_three_reactions_cross_phase():
+    return {
+        "num_reactions": 3,
+        "reaction_type_000": "MASS_ACTION_LAW",
+        "kfwd_liquid_000": 1.0,
+        "kbwd_liquid_000": 1.0,
+        "stoichiometric_matrix_liquid_000": [[-1], [1], [0]],
+        "kfwd_solid_000": 0.5,
+        "kbwd_solid_000": 0.3,
+        "stoichiometric_matrix_solid_000": [[0], [0], [1]],
+        "reaction_type_001": "MASS_ACTION_LAW",
+        "kfwd_liquid_001": 0.8,
+        "kbwd_liquid_001": 0.4,
+        "stoichiometric_matrix_liquid_001": [[-1], [0], [1]],
+        "kfwd_solid_001": 0.6,
+        "kbwd_solid_001": 0.2,
+        "stoichiometric_matrix_solid_001": [[0], [1], [-1]],
+        "reaction_type_002": "MASS_ACTION_LAW",
+        "kfwd_liquid_002": 0.7,
+        "kbwd_liquid_002": 0.5,
+        "stoichiometric_matrix_liquid_002": [[0], [-1], [1]],
+        "kfwd_solid_002": 0.9,
+        "kbwd_solid_002": 0.1,
+        "stoichiometric_matrix_solid_002": [[1], [0], [-1]]
+    }
+
+def get_dict_one_reaction_particle():
+    return {
+        "num_reactions": 1,
+        "reaction_type_000": "MASS_ACTION_LAW",
+        "stoichiometric_matrix_000": [[-1], [1], [0]],
+        "kfwd_000": [1.0],
+        "kbwd_000": [1.0]
+    }
+
+def get_dict_two_reactions_particle():
+    return {
+        "num_reactions": 2,
+        "reaction_type_000": "MASS_ACTION_LAW",
+        "stoichiometric_matrix_000": [[-1], [1], [0]],
+        "kfwd_000": [1.0],
+        "kbwd_000": [1.0],
+        "reaction_type_001": "MASS_ACTION_LAW",
+        "stoichiometric_matrix_001": [[0], [-1], [1]],
+        "kfwd_001": [0.5],
+        "kbwd_001": [0.3]
+    }
+
+def get_dict_three_reactions_particle():
+    return {
+        "num_reactions": 3,
+        "reaction_type_000": "MASS_ACTION_LAW",
+        "stoichiometric_matrix_000": [[-1], [1], [0]],
+        "kfwd_000": [1.0],
+        "kbwd_000": [1.0],
+        "reaction_type_001": "MASS_ACTION_LAW",
+        "stoichiometric_matrix_001": [[0], [-1], [1]],
+        "kfwd_001": [0.5],
+        "kbwd_001": [0.3],
+        "reaction_type_002": "MASS_ACTION_LAW",
+        "stoichiometric_matrix_002": [[-1], [0], [1]],
+        "kfwd_002": [0.8],
+        "kbwd_002": [0.4]
+    }

--- a/src/multiple_reaction_configs.py
+++ b/src/multiple_reaction_configs.py
@@ -1,3 +1,4 @@
+from xml.parsers.expat import model
 import numpy as np
 
 def cstr_setup(model):
@@ -125,6 +126,75 @@ def lrmp_setup(model):
 
     return model
 
+def lrm_setup(model):
+
+    ncomp = 3
+    init_c = [1.0, 2.0, 3.0]
+    sim_time = 10.0
+
+    model.root.input.model.nunits = 1
+
+    model.root.input.model.unit_000.unit_type = 'LUMPED_RATE_MODEL_WITHOUT_PORES'
+    model.root.input.model.unit_000.ncomp = ncomp
+    model.root.input.model.unit_000.nbound = [1.0] * ncomp
+    model.root.input.model.unit_000.init_c = init_c
+    model.root.input.model.unit_000.init_q = [1.0, 2.0, 3.0]
+    model.root.input.model.unit_000.col_dispersion = 1e-5
+    model.root.input.model.unit_000.col_length  = 0.6
+    model.root.input.model.unit_000.total_porosity  = 0.37
+
+    model.root.input.model.unit_000.cross_section_area = 1.0386890710931253E-4
+
+    model.root.input.model.unit_000.discretization.ncol                  = 1
+    model.root.input.model.unit_000.discretization.use_analytic_jacobian = 1
+    model.root.input.model.unit_000.discretization.weno.boundary_model   = 0
+    model.root.input.model.unit_000.discretization.weno.weno_eps         = 1e-10
+    model.root.input.model.unit_000.discretization.weno.weno_order       = 1
+    model.root.input.model.unit_000.discretization.max_restarts          = 10
+    model.root.input.model.unit_000.discretization.gs_type              = 1
+    model.root.input.model.unit_000.discretization.max_krylov           = 0
+    model.root.input.model.unit_000.discretization.schur_safety          = 1e-8
+    model.root.input.model.unit_000.discretization.reconstruction = 'WENO'
+    model.root.input.model.unit_000.discretization.par_disc_type = 'EQUIDISTANT_PAR'
+
+    # Adsorption model -> have to be set
+    model.root.input.model.unit_000.adsorption_model = 'LINEAR'
+    model.root.input.model.unit_000.adsorption.is_kinetic  = True
+    model.root.input.model.unit_000.adsorption.lin_ka = [0,0,0]
+    model.root.input.model.unit_000.adsorption.lin_kd = [0,0,0]
+
+
+    """Configure solver settings"""
+    model.root.input.solver.user_solution_times = np.linspace(0, sim_time, 1000)
+    model.root.input.solver.sections.nsec = 1
+    model.root.input.solver.sections.section_times = [0.0, sim_time]
+    model.root.input.solver.sections.section_continuity = 0
+
+    model.root.input.model.solver.gs_type = 1
+    model.root.input.model.solver.max_krylov = 0
+    model.root.input.model.solver.max_restarts = 10
+    model.root.input.model.solver.schur_safety = 1e-8
+
+    model.root.input.solver.time_integrator.abstol = 1e-6
+    model.root.input.solver.time_integrator.algtol = 1e-10
+    model.root.input.solver.time_integrator.reltol = 1e-6
+    model.root.input.solver.time_integrator.init_step_size = 1e-6
+    model.root.input.solver.time_integrator.max_steps = 1000000
+    model.root.input.solver.consistent_init_mode = 1
+
+    model.root.input.model.connections.nswitches = 1
+    model.root.input.model.connections.switch_000.section = 0
+    model.root.input.model.connections.switch_000.connections = []
+
+    model.root.input['return'].split_components_data = 0
+    model.root.input['return'].split_ports_data = 0
+    model.root.input['return'].unit_000.write_solution_bulk = 1
+    model.root.input['return'].unit_000.write_solution_inlet = 0
+    model.root.input['return'].unit_000.write_solution_outlet = 0
+    model.root.input['return'].unit_000.write_sens_outlet = 0
+
+    return model
+
 def grm_setup(model):
     
     ncomp = 3
@@ -216,8 +286,72 @@ def grm_setup(model):
 
     return model
 
+def mct_setup(model):
+
+    ncomp = 3
+    init_c = [1.0, 2.0, 3.0]
+    sim_time = 10.0
+
+    model.root.input.model.nunits = 1
+
+    model.root.input.model.unit_000.unit_type                   = 'MULTI_CHANNEL_TRANSPORT'
+    model.root.input.model.unit_000.ncomp                       = ncomp
+
+    model.root.input.model.unit_000.col_length                  = 0.6
+    model.root.input.model.unit_000.channel_cross_section_areas = [1e-4, 1e-4]
+    model.root.input.model.unit_000.col_dispersion              =  1e-5
+    model.root.input.model.unit_000.init_c                      = init_c
+    model.root.input.model.unit_000.velocity                    = 1
+    model.root.input.model.unit_000.nchannel                    = 2
+    model.root.input.model.unit_000.exchange_matrix             = [[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                                                                   [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]
+
+
+    """Configure solver settings"""
+    model.root.input.solver.user_solution_times = np.linspace(0, sim_time, 1000)
+    model.root.input.solver.sections.nsec = 1
+    model.root.input.solver.sections.section_times = [0.0, sim_time]
+    model.root.input.solver.sections.section_continuity = 0
+
+    model.root.input.model.solver.gs_type = 1
+    model.root.input.model.solver.max_krylov = 0
+    model.root.input.model.solver.max_restarts = 10
+    model.root.input.model.solver.schur_safety = 1e-8
+
+    model.root.input.solver.time_integrator.abstol = 1e-6
+    model.root.input.solver.time_integrator.algtol = 1e-10
+    model.root.input.solver.time_integrator.reltol = 1e-6
+    model.root.input.solver.time_integrator.init_step_size = 1e-6
+    model.root.input.solver.time_integrator.max_steps = 1000000
+    model.root.input.solver.consistent_init_mode = 1
+
+    model.root.input.model.connections.nswitches = 1
+    model.root.input.model.connections.switch_000.section = 0
+    model.root.input.model.connections.switch_000.connections = []
+
+    model.root.input['return'].split_components_data = 0
+    model.root.input['return'].split_ports_data = 0
+    model.root.input['return'].unit_000.write_solution_bulk = 1
+    model.root.input['return'].unit_000.write_solution_inlet = 0
+    model.root.input['return'].unit_000.write_solution_outlet = 0
+    model.root.input['return'].unit_000.write_sens_outlet = 0
+
+    model.root.input.model.unit_000.discretization.ncol                  = 1
+    model.root.input.model.unit_000.discretization.use_analytic_jacobian = 1
+    model.root.input.model.unit_000.discretization.weno.boundary_model   = 0
+    model.root.input.model.unit_000.discretization.weno.weno_eps         = 1e-10
+    model.root.input.model.unit_000.discretization.weno.weno_order       = 1
+    model.root.input.model.unit_000.discretization.max_restarts          = 10
+    model.root.input.model.unit_000.discretization.gs_type              = 1
+    model.root.input.model.unit_000.discretization.max_krylov           = 0
+    model.root.input.model.unit_000.discretization.schur_safety          = 1e-8
+    model.root.input.model.unit_000.discretization.reconstruction = 'WENO'
+    model.root.input.model.unit_000.discretization.par_disc_type = 'EQUIDISTANT_PAR'
+
+    return model
+
 def mal_setup_particle_old(model, reaction_dict):
-    
+
     #Configure the reaction system
     model.root.input.model.unit_000.reaction_model_particles = reaction_dict[f"reaction_type_000"]
     model.root.input.model.unit_000.reaction_particle_000.mal_kfwd_liquid = [reaction_dict[f'kfwd_liquid_000']]
@@ -261,35 +395,35 @@ def mal_setup_bulk(model, reaction_dict):
     return model
 
 def mal_setup_cross_phase(model, reaction_dict):
-    
+
     #Configure the reaction system
+    model.root.input.model.unit_000.reaction_cross_phase_000.nreac = reaction_dict['num_reactions']
+    for i in range(reaction_dict['num_reactions']):
+        reaction_model = getattr(model.root.input.model.unit_000.reaction_cross_phase_000, f"reaction_model_{i:03d}")
 
-    model.root.input.model.unit_000.reaction_model_particles = reaction_dict[f"reaction_type_000"]
-    model.root.input.model.unit_000.reaction_particle_000.mal_kfwd_liquid = [reaction_dict[f'kfwd_liquid_000']]
-    model.root.input.model.unit_000.reaction_particle_000.mal_kbwd_liquid = [reaction_dict[f'kbwd_liquid_000']]
+        reaction_model.reaction_type = reaction_dict[f"reaction_type_{i:03d}"]
 
-        # Stoichiometry matrix 2D array [components][reaction]
-    model.root.input.model.unit_000.reaction_particle_000.mal_stoichiometry_liquid = reaction_dict[f'stoichiometric_matrix_liquid_000']
+        reaction_model.mal_kfwd_liquid = [reaction_dict[f'kfwd_liquid_{i:03d}']]
+        reaction_model.mal_kbwd_liquid = [reaction_dict[f'kbwd_liquid_{i:03d}']]
+        reaction_model.mal_stoichiometry_liquid = reaction_dict[f'stoichiometric_matrix_liquid_{i:03d}']
 
-    model.root.input.model.unit_000.reaction_particle_000.mal_kfwd_solid = [reaction_dict[f'kfwd_solid_000']]
-    model.root.input.model.unit_000.reaction_particle_000.mal_kbwd_solid = [reaction_dict[f'kbwd_solid_000']]
-
-        # Stoichiometry matrix 2D array [components][reaction]
-    model.root.input.model.unit_000.reaction_particle_000.mal_stoichiometry_solid = reaction_dict[f'stoichiometric_matrix_solid_000']
+        reaction_model.mal_kfwd_solid = [reaction_dict[f'kfwd_solid_{i:03d}']]
+        reaction_model.mal_kbwd_solid = [reaction_dict[f'kbwd_solid_{i:03d}']]
+        reaction_model.mal_stoichiometry_solid = reaction_dict[f'stoichiometric_matrix_solid_{i:03d}']
 
     return model
 
-def mal_setup_paricle(model, reaction_dict):
-    
+def mal_setup_particle(model, reaction_dict):
+
     #Configure the reaction system
-    model.root.input.model.unit_000.reaction_particle.nreac = reaction_dict['num_reactions']
+    model.root.input.model.unit_000.reaction_particle_000.nreac = reaction_dict['num_reactions']
     for i in range(reaction_dict['num_reactions']):
-        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").reaction_type = reaction_dict[f"reaction_type_{i:03d}"]
-        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").mal_kfwd = [reaction_dict[f'kfwd_{i:03d}']]
-        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").mal_kbwd = [reaction_dict[f'kbwd_{i:03d}']]
+        getattr(model.root.input.model.unit_000.reaction_particle_000, f"reaction_model_{i:03d}").reaction_type = reaction_dict[f"reaction_type_{i:03d}"]
+        getattr(model.root.input.model.unit_000.reaction_particle_000, f"reaction_model_{i:03d}").mal_kfwd = [reaction_dict[f'kfwd_{i:03d}']]
+        getattr(model.root.input.model.unit_000.reaction_particle_000, f"reaction_model_{i:03d}").mal_kbwd = [reaction_dict[f'kbwd_{i:03d}']]
 
         # Stoichiometry matrix 2D array [components][reaction]
-        getattr(model.root.input.model.unit_000.reaction_particle, f"reaction_model_{i:03d}").mal_stoichiometry = reaction_dict[f'stoichiometric_matrix_{i:03d}']
+        getattr(model.root.input.model.unit_000.reaction_particle_000, f"reaction_model_{i:03d}").mal_stoichiometry = reaction_dict[f'stoichiometric_matrix_{i:03d}']
 
     return model
 
@@ -301,8 +435,8 @@ def get_dict_one_reaction_mal():
     "stoichiometric_matrix_000": [[-1, -1, 0],
                                 [1, 1, -1],
                                 [1, 0, 1]],
-    "kfwd_000": [1.0, 0.5, 1.0],
-    "kbwd_000": [1.0, 0.3, 1.0]
+    "kfwd_000": [1.0, 1.0, 1.0],
+    "kbwd_000": [1.0, 1.0, 1.0]
 }
 
 def get_dict_two_reaction_mal():
@@ -313,8 +447,8 @@ def get_dict_two_reaction_mal():
     "stoichiometric_matrix_000": [[-1, -1],
                                     [1, 1],
                                     [1, 0]],
-    "kfwd_000": [1.0, 0.5],
-    "kbwd_000": [1.0, 0.3], 
+    "kfwd_000": [1.0, 1.0],
+    "kbwd_000": [1.0, 1.0], 
     "reaction_type_001": "MASS_ACTION_LAW",
     "stoichiometric_matrix_001": [[0],
                                 [-1],
@@ -322,7 +456,7 @@ def get_dict_two_reaction_mal():
     "kfwd_001": [1.0],
     "kbwd_001": [1.0]
 
-    }
+}
 
 def get_dict_three_reaction_mal():
     return {
@@ -333,106 +467,92 @@ def get_dict_three_reaction_mal():
     "kbwd_000": [1.0],
     "reaction_type_001": "MASS_ACTION_LAW",
     "stoichiometric_matrix_001": [[-1], [1], [0]],
-    "kfwd_001": [0.5],
-    "kbwd_001": [0.3],
+    "kfwd_001": [1.0],
+    "kbwd_001": [1.0],
     "reaction_type_002": "MASS_ACTION_LAW",
     "stoichiometric_matrix_002": [[0], [-1], [1]],
     "kfwd_002": [1.0],
     "kbwd_002": [1.0]
-    }
+}
 
 def get_dict_one_reaction_cross_phase():
-    return {
-        "num_reactions": 1,
-        "reaction_type_000": "MASS_ACTION_LAW",
-        "kfwd_liquid_000": 1.0,
-        "kbwd_liquid_000": 1.0,
-        "stoichiometric_matrix_liquid_000": [[-1], [1], [0]],
-        "kfwd_solid_000": 0.5,
-        "kbwd_solid_000": 0.3,
-        "stoichiometric_matrix_solid_000": [[0], [0], [1]]
-    }
+    return  {
+    "num_reactions": 1,
+    "reaction_type_000": "MASS_ACTION_LAW_CROSS_PHASE",
+    "stoichiometric_matrix_liquid_000": [[-1, -1, 0],
+                                [1, 1, -1],
+                                [1, 0, 1]],
+    "stoichiometric_matrix_solid_000": [[0, 0, -1],
+                                [0, 0, 1],
+                                [0, 1, 0]],
+    "kfwd_solid_000": [1.0, 0.5, 1.0],
+    "kbwd_solid_000": [1.0, 0.3, 1.0],
+    "kfwd_liquid_000": [1.0, 0.5, 1.0],
+    "kbwd_liquid_000": [1.0, 0.3, 1.0]
+}
 
 def get_dict_two_reactions_cross_phase():
     return {
-        "num_reactions": 2,
-        "reaction_type_000": "MASS_ACTION_LAW",
-        "kfwd_liquid_000": 1.0,
-        "kbwd_liquid_000": 1.0,
-        "stoichiometric_matrix_liquid_000": [[-1], [1], [0]],
-        "kfwd_solid_000": 0.5,
-        "kbwd_solid_000": 0.3,
-        "stoichiometric_matrix_solid_000": [[0], [0], [1]],
-        "reaction_type_001": "MASS_ACTION_LAW",
-        "kfwd_liquid_001": 0.8,
-        "kbwd_liquid_001": 0.4,
-        "stoichiometric_matrix_liquid_001": [[-1], [0], [1]],
-        "kfwd_solid_001": 0.6,
-        "kbwd_solid_001": 0.2,
-        "stoichiometric_matrix_solid_001": [[0], [1], [-1]]
-    }
+    "num_reactions": 2,
+    "reaction_type_000": "MASS_ACTION_LAW_CROSS_PHASE",
+    "stoichiometric_matrix_liquid_000": [[-1, -1],
+                                [1, 1],
+                                [1, 0]],
+    "stoichiometric_matrix_solid_000": [[0, 0],
+                                [0, 0],
+                                [0, 1]],
+    "kfwd_solid_000": [1.0, 0.5],
+    "kbwd_solid_000": [1.0, 0.3],
+    "kfwd_liquid_000": [1.0, 0.5],
+    "kbwd_liquid_000": [1.0, 0.3],
+   "reaction_type_001": "MASS_ACTION_LAW_CROSS_PHASE",
+    "stoichiometric_matrix_liquid_001": [[-0],
+                                [-1],
+                                [ 1]],
+    "stoichiometric_matrix_solid_001": [[-1],
+                                [1],
+                                [0]],
+    "kfwd_solid_001": [1.0],
+    "kbwd_solid_001": [ 1.0],
+    "kfwd_liquid_001": [ 1.0],
+    "kbwd_liquid_001": [ 1.0]
+
+}
 
 def get_dict_three_reactions_cross_phase():
     return {
-        "num_reactions": 3,
-        "reaction_type_000": "MASS_ACTION_LAW",
-        "kfwd_liquid_000": 1.0,
-        "kbwd_liquid_000": 1.0,
-        "stoichiometric_matrix_liquid_000": [[-1], [1], [0]],
-        "kfwd_solid_000": 0.5,
-        "kbwd_solid_000": 0.3,
-        "stoichiometric_matrix_solid_000": [[0], [0], [1]],
-        "reaction_type_001": "MASS_ACTION_LAW",
-        "kfwd_liquid_001": 0.8,
-        "kbwd_liquid_001": 0.4,
-        "stoichiometric_matrix_liquid_001": [[-1], [0], [1]],
-        "kfwd_solid_001": 0.6,
-        "kbwd_solid_001": 0.2,
-        "stoichiometric_matrix_solid_001": [[0], [1], [-1]],
-        "reaction_type_002": "MASS_ACTION_LAW",
-        "kfwd_liquid_002": 0.7,
-        "kbwd_liquid_002": 0.5,
-        "stoichiometric_matrix_liquid_002": [[0], [-1], [1]],
-        "kfwd_solid_002": 0.9,
-        "kbwd_solid_002": 0.1,
-        "stoichiometric_matrix_solid_002": [[1], [0], [-1]]
-    }
-
-def get_dict_one_reaction_particle():
-    return {
-        "num_reactions": 1,
-        "reaction_type_000": "MASS_ACTION_LAW",
-        "stoichiometric_matrix_000": [[-1], [1], [0]],
-        "kfwd_000": [1.0],
-        "kbwd_000": [1.0]
-    }
-
-def get_dict_two_reactions_particle():
-    return {
-        "num_reactions": 2,
-        "reaction_type_000": "MASS_ACTION_LAW",
-        "stoichiometric_matrix_000": [[-1], [1], [0]],
-        "kfwd_000": [1.0],
-        "kbwd_000": [1.0],
-        "reaction_type_001": "MASS_ACTION_LAW",
-        "stoichiometric_matrix_001": [[0], [-1], [1]],
-        "kfwd_001": [0.5],
-        "kbwd_001": [0.3]
-    }
-
-def get_dict_three_reactions_particle():
-    return {
-        "num_reactions": 3,
-        "reaction_type_000": "MASS_ACTION_LAW",
-        "stoichiometric_matrix_000": [[-1], [1], [0]],
-        "kfwd_000": [1.0],
-        "kbwd_000": [1.0],
-        "reaction_type_001": "MASS_ACTION_LAW",
-        "stoichiometric_matrix_001": [[0], [-1], [1]],
-        "kfwd_001": [0.5],
-        "kbwd_001": [0.3],
-        "reaction_type_002": "MASS_ACTION_LAW",
-        "stoichiometric_matrix_002": [[-1], [0], [1]],
-        "kfwd_002": [0.8],
-        "kbwd_002": [0.4]
-    }
+    "num_reactions": 3,
+   "reaction_type_000": "MASS_ACTION_LAW_CROSS_PHASE",
+    "stoichiometric_matrix_liquid_000": [[-1],
+                                [1],
+                                [1]],
+    "stoichiometric_matrix_solid_000": [[0],
+                                [0],
+                                [0]],
+    "kfwd_solid_000": [1.0],
+    "kbwd_solid_000": [1.0],
+    "kfwd_liquid_000": [1.0],
+    "kbwd_liquid_000": [1.0],
+    "reaction_type_001": "MASS_ACTION_LAW_CROSS_PHASE",
+    "stoichiometric_matrix_liquid_001": [[ -1],
+                                [ 1],
+                                [ 0]],
+    "stoichiometric_matrix_solid_001": [[ 0],
+                                [ 0],
+                                [1]],
+    "kfwd_solid_001": [ 0.5],
+    "kbwd_solid_001": [ 0.3],
+    "kfwd_liquid_001": [ 0.5],
+    "kbwd_liquid_001": [ 0.3],
+    "reaction_type_002": "MASS_ACTION_LAW_CROSS_PHASE",
+    "stoichiometric_matrix_liquid_002": [[-0],
+                                [-1],
+                                [ 1]],
+    "stoichiometric_matrix_solid_002": [[-1],
+                                [1],
+                                [0]],
+    "kfwd_solid_002": [1.0],
+    "kbwd_solid_002": [ 1.0],
+    "kfwd_liquid_002": [ 1.0],
+    "kbwd_liquid_002": [ 1.0]
+}

--- a/src/multiple_reactions.py
+++ b/src/multiple_reactions.py
@@ -1,149 +1,11 @@
 import numpy as np
 from cadet import Cadet
 import multiple_reaction_configs as MRC
-
-
-def multiple_reactions_cstr_test_bulk(output_path, cadet_path, plot=False):
-    
-    # old interface bulk
-    case_bulk_mal_old = MRC.get_dict_one_reaction_mal()
-    
-    model_bulk_mal_old = Cadet(cadet_path)
-    model_bulk_mal_old = MRC.cstr_setup(model_bulk_mal_old)
-    model_bulk_mal_old = MRC.mal_setup_bulk_old(model_bulk_mal_old,case_bulk_mal_old)
-    
-    model_bulk_mal_old.filename = f"cstr_{case_bulk_mal_old['num_reactions']}_reaction_old.h5"
-    model_bulk_mal_old.save()
-    data_bulk_mal_old = model_bulk_mal_old.run_simulation()
-    print(data_bulk_mal_old.return_code)
-    print(data_bulk_mal_old.error_message)
-
-
-    # new interface bulk 1 reaction
-    case_bulk_mal_one = MRC.get_dict_one_reaction_mal()
-    
-    model_bulk_mal_one = Cadet(cadet_path)
-    model_bulk_mal_one = MRC.cstr_setup(model_bulk_mal_one)
-    model_bulk_mal_one = MRC.mal_setup_bulk(model_bulk_mal_one, case_bulk_mal_one)
-    model_bulk_mal_one.filename = f"cstr_{case_bulk_mal_one['num_reactions']}_reaction_new.h5"
-    model_bulk_mal_one.save()
-    data_bulk_mal_one = model_bulk_mal_one.run_simulation()
-    print(data_bulk_mal_one.return_code)
-    print(data_bulk_mal_one.error_message)
-
-    # new interface bulk 2 reactions
-    case_bulk_mal_two = MRC.get_dict_two_reaction_mal()
-    model_bulk_mal_two = Cadet(cadet_path)
-    model_bulk_mal_two = MRC.cstr_setup(model_bulk_mal_two)
-    model_bulk_mal_two = MRC.mal_setup_bulk(model_bulk_mal_two, case_bulk_mal_two)
-    model_bulk_mal_two.filename = f"cstr_{case_bulk_mal_two['num_reactions']}_reaction_new.h5"
-    model_bulk_mal_two.save()
-    data_bulk_mal_two = model_bulk_mal_two.run_simulation()
-    print(data_bulk_mal_two.return_code)
-    print(data_bulk_mal_two.error_message)
-
-    # new interface bulk 3 reactions 
-    case_bulk_mal_three = MRC.get_dict_three_reaction_mal()
-    model_bulk_mal_three = Cadet(cadet_path)
-    model_bulk_mal_three = MRC.cstr_setup(model_bulk_mal_three)
-    model_bulk_mal_three = MRC.mal_setup_bulk(model_bulk_mal_three, case_bulk_mal_three)
-    model_bulk_mal_three.filename = f"cstr_{case_bulk_mal_three['num_reactions']}_reaction_new.h5"
-    model_bulk_mal_three.save()
-    data_bulk_mal_three = model_bulk_mal_three.run_simulation()
-    print(data_bulk_mal_three.return_code)
-    print(data_bulk_mal_three.error_message)
-
-    # compare results
-
-    if plot:
-        import matplotlib.pyplot as plt
-        plt.figure()
-        plt.plot(model_bulk_mal_old.root.output.solution.solution_times, model_bulk_mal_old.root.output.solution.unit_000.solution_bulk, label='Old Interface - Reaction 1')
-        plt.plot(model_bulk_mal_one.root.output.solution.solution_times, model_bulk_mal_one.root.output.solution.unit_000.solution_bulk, label='New Interface - Reaction 1')
-        plt.plot(model_bulk_mal_two.root.output.solution.solution_times, model_bulk_mal_two.root.output.solution.unit_000.solution_bulk, label='New Interface - Reaction 2')
-        plt.plot(model_bulk_mal_three.root.output.solution.solution_times, model_bulk_mal_three.root.output.solution.unit_000.solution_bulk[:, 0], label='New Interface - Reaction 3')
-        plt.xlabel('Time')
-        plt.ylabel('Concentration')
-        plt.legend()
-        plt.title('CSTR Multiple Reactions Comparison')
-        #plt.savefig(output_path + '/cstr_multiple_reactions_bulk_comparison.png')
-        plt.show()
-    
-    # print max absolut error
-    max_error_1 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_one.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between old and new interface for 1 reaction: {max_error_1}')
-
-    max_error_2 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_two.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between old and new interface for 2 reactions: {max_error_2}')
-    
-    max_error_3 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between old and new interface for 3 reactions: {max_error_3}')
-
-
-def multiple_reactions_cstr_test_cross_phase(output_path, cadet_path, plot=False):
-    
-    # new interface cross_phase 1 reaction
-    case_cross_phase_one = MRC.get_dict_one_reaction_cross_phase()
-    
-    model_cross_phase_one = Cadet(cadet_path)
-    model_cross_phase_one = MRC.lrmp_setup(model_cross_phase_one)
-    model_cross_phase_one = MRC.mal_setup_cross_phase(model_cross_phase_one, case_cross_phase_one)
-    
-    model_cross_phase_one.filename = f"lrmp_{case_cross_phase_one['num_reactions']}_reaction_cross_phase.h5"
-    model_cross_phase_one.save()
-    data_cross_phase_one = model_cross_phase_one.run_simulation()
-    print(data_cross_phase_one.return_code)
-    print(data_cross_phase_one.error_message)
-
-    # new interface cross_phase 2 reactions
-    case_cross_phase_two = MRC.get_dict_two_reactions_cross_phase()
-    model_cross_phase_two = Cadet(cadet_path)
-    model_cross_phase_two = MRC.lrmp_setup(model_cross_phase_two)
-    model_cross_phase_two = MRC.mal_setup_cross_phase(model_cross_phase_two, case_cross_phase_two)
-    model_cross_phase_two.filename = f"lrmp_{case_cross_phase_two['num_reactions']}_reaction_cross_phase.h5"
-    model_cross_phase_two.save()
-    data_cross_phase_two = model_cross_phase_two.run_simulation()
-    print(data_cross_phase_two.return_code)
-    print(data_cross_phase_two.error_message)
-
-    # new interface cross_phase 3 reactions 
-    case_cross_phase_three = MRC.get_dict_three_reactions_cross_phase()
-    model_cross_phase_three = Cadet(cadet_path)
-    model_cross_phase_three = MRC.lrmp_setup(model_cross_phase_three)
-    model_cross_phase_three = MRC.mal_setup_cross_phase(model_cross_phase_three, case_cross_phase_three)
-    model_cross_phase_three.filename = f"lrmp_{case_cross_phase_three['num_reactions']}_reaction_cross_phase.h5"
-    model_cross_phase_three.save()
-    data_cross_phase_three = model_cross_phase_three.run_simulation()
-    print(data_cross_phase_three.return_code)
-    print(data_cross_phase_three.error_message)
-
-    # compare results
-    if plot:
-        import matplotlib.pyplot as plt
-        plt.figure()
-        plt.plot(model_cross_phase_one.root.output.solution.solution_times, model_cross_phase_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 1 Reaction')
-        plt.plot(model_cross_phase_two.root.output.solution.solution_times, model_cross_phase_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 2 Reactions')
-        plt.plot(model_cross_phase_three.root.output.solution.solution_times, model_cross_phase_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 3 Reactions')
-        plt.xlabel('Time')
-        plt.ylabel('Concentration')
-        plt.legend()
-        plt.title('LRMP Multiple Cross Phase Reactions Comparison')
-        #plt.savefig(output_path + '/lrmp_multiple_reactions_cross_phase_comparison.png')
-        plt.show()
-    
-    # print max absolut error
-    max_error_1_2 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_two.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 2 cross phase reactions: {max_error_1_2}')
-
-    max_error_1_3 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 3 cross phase reactions: {max_error_1_3}')
-    
-    max_error_2_3 = np.max(np.abs(model_cross_phase_two.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 2 and 3 cross phase reactions: {max_error_2_3}')
+import pytest
 
 
 def multiple_reactions_cstr_test_particle(output_path, cadet_path, plot=False):
-    
+
     # new interface particle 1 reaction
     case_particle_one = MRC.get_dict_one_reaction_particle()
     
@@ -154,7 +16,8 @@ def multiple_reactions_cstr_test_particle(output_path, cadet_path, plot=False):
     model_particle_one.filename = f"lrmp_{case_particle_one['num_reactions']}_reaction_particle.h5"
     model_particle_one.save()
     data_particle_one = model_particle_one.run_simulation()
-    print(data_particle_one.return_code)
+    if data_particle_one.return_code != 0:
+        print(data_particle_one.return_code)
     print(data_particle_one.error_message)
 
     # new interface particle 2 reactions
@@ -165,7 +28,8 @@ def multiple_reactions_cstr_test_particle(output_path, cadet_path, plot=False):
     model_particle_two.filename = f"lrmp_{case_particle_two['num_reactions']}_reaction_particle.h5"
     model_particle_two.save()
     data_particle_two = model_particle_two.run_simulation()
-    print(data_particle_two.return_code)
+    if data_particle_two.return_code != 0:
+            print(data_particle_two.return_code)
     print(data_particle_two.error_message)
 
     # new interface particle 3 reactions 
@@ -176,7 +40,8 @@ def multiple_reactions_cstr_test_particle(output_path, cadet_path, plot=False):
     model_particle_three.filename = f"lrmp_{case_particle_three['num_reactions']}_reaction_particle.h5"
     model_particle_three.save()
     data_particle_three = model_particle_three.run_simulation()
-    print(data_particle_three.return_code)
+    if data_particle_three.return_code != 0:
+        print(data_particle_three.return_code)
     print(data_particle_three.error_message)
 
     # compare results
@@ -193,19 +58,19 @@ def multiple_reactions_cstr_test_particle(output_path, cadet_path, plot=False):
         #plt.savefig(output_path + '/lrmp_multiple_reactions_particle_comparison.png')
         plt.show()
     
-    # print max absolut error
+    # check max absolut error with tolerance
+    tolerance = 1e-10
     max_error_1_2 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_two.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 2 particle reactions: {max_error_1_2}')
+    assert max_error_1_2 < tolerance, f'  WARNING: Max error between 1 and 2 particle reactions ({max_error_1_2}) exceeds tolerance ({tolerance})'
 
     max_error_1_3 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 3 particle reactions: {max_error_1_3}')
+    assert max_error_1_3 < tolerance, f'  WARNING: Max error between 1 and 3 particle reactions ({max_error_1_3}) exceeds tolerance ({tolerance})'
     
     max_error_2_3 = np.max(np.abs(model_particle_two.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 2 and 3 particle reactions: {max_error_2_3}')
-
+    assert max_error_2_3 < tolerance, f'  WARNING: Max error between 2 and 3 particle reactions ({max_error_2_3}) exceeds tolerance ({tolerance})'
 
 def multiple_reactions_lrmp_test_bulk(output_path, cadet_path, plot=False):
-    
+
     # old interface bulk
     case_bulk_mal_old = MRC.get_dict_one_reaction_mal()
     
@@ -216,7 +81,8 @@ def multiple_reactions_lrmp_test_bulk(output_path, cadet_path, plot=False):
     model_bulk_mal_old.filename = f"lrmp_{case_bulk_mal_old['num_reactions']}_reaction_bulk_old.h5"
     model_bulk_mal_old.save()
     data_bulk_mal_old = model_bulk_mal_old.run_simulation()
-    print(data_bulk_mal_old.return_code)
+    if data_bulk_mal_old.return_code != 0:
+        print(data_bulk_mal_old.return_code)
     print(data_bulk_mal_old.error_message)
 
     # new interface bulk 1 reaction
@@ -228,29 +94,32 @@ def multiple_reactions_lrmp_test_bulk(output_path, cadet_path, plot=False):
     model_bulk_mal_one.filename = f"lrmp_{case_bulk_mal_one['num_reactions']}_reaction_bulk_new.h5"
     model_bulk_mal_one.save()
     data_bulk_mal_one = model_bulk_mal_one.run_simulation()
-    print(data_bulk_mal_one.return_code)
+    if data_bulk_mal_one.return_code != 0:
+        print(data_bulk_mal_one.return_code)
     print(data_bulk_mal_one.error_message)
 
     # new interface bulk 2 reactions
-    case_bulk_mal_two = MRC.get_dict_two_reactions_mal()
+    case_bulk_mal_two = MRC.get_dict_two_reaction_mal()
     model_bulk_mal_two = Cadet(cadet_path)
     model_bulk_mal_two = MRC.lrmp_setup(model_bulk_mal_two)
     model_bulk_mal_two = MRC.mal_setup_bulk(model_bulk_mal_two, case_bulk_mal_two)
     model_bulk_mal_two.filename = f"lrmp_{case_bulk_mal_two['num_reactions']}_reaction_bulk_new.h5"
     model_bulk_mal_two.save()
     data_bulk_mal_two = model_bulk_mal_two.run_simulation()
-    print(data_bulk_mal_two.return_code)
+    if data_bulk_mal_two.return_code != 0:
+        print(data_bulk_mal_two.return_code)
     print(data_bulk_mal_two.error_message)
 
     # new interface bulk 3 reactions 
-    case_bulk_mal_three = MRC.get_dict_three_reactions_mal()
+    case_bulk_mal_three = MRC.get_dict_three_reaction_mal()
     model_bulk_mal_three = Cadet(cadet_path)
     model_bulk_mal_three = MRC.lrmp_setup(model_bulk_mal_three)
     model_bulk_mal_three = MRC.mal_setup_bulk(model_bulk_mal_three, case_bulk_mal_three)
     model_bulk_mal_three.filename = f"lrmp_{case_bulk_mal_three['num_reactions']}_reaction_bulk_new.h5"
     model_bulk_mal_three.save()
     data_bulk_mal_three = model_bulk_mal_three.run_simulation()
-    print(data_bulk_mal_three.return_code)
+    if data_bulk_mal_three.return_code != 0:
+        print(data_bulk_mal_three.return_code)
     print(data_bulk_mal_three.error_message)
 
     # compare results
@@ -268,18 +137,95 @@ def multiple_reactions_lrmp_test_bulk(output_path, cadet_path, plot=False):
         #plt.savefig(output_path + '/lrmp_multiple_reactions_bulk_comparison.png')
         plt.show()
     
-    # print max absolut error
+    # check max absolut error with tolerance
+    tolerance = 1e-10
     max_error_1 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_one.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between old and new interface for 1 reaction: {max_error_1}')
+    assert max_error_1 < tolerance, f'  WARNING: Max error between old and new interface for 1 reaction ({max_error_1}) exceeds tolerance ({tolerance})'
 
     max_error_2 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_two.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between old and new interface for 2 reactions: {max_error_2}')
+    assert max_error_2 < tolerance, f'  WARNING: Max error between old and new interface for 2 reactions ({max_error_2}) exceeds tolerance ({tolerance})'
     
     max_error_3 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between old and new interface for 3 reactions: {max_error_3}')
+    assert max_error_3 < tolerance, f'  WARNING: Max error between old and new interface for 3 reactions ({max_error_3}) exceeds tolerance ({tolerance})'
 
+def multiple_reactions_lrmp_test_particle(output_path, cadet_path, plot=False):
+
+    # new interface particle 1 reaction
+    case_particle_one = MRC.get_dict_one_reaction_mal()
+    
+    model_particle_one = Cadet(cadet_path)
+    model_particle_one = MRC.lrmp_setup(model_particle_one)
+    model_particle_one = MRC.mal_setup_particle(model_particle_one, case_particle_one)
+    
+    model_particle_one.filename = f"lrmp_{case_particle_one['num_reactions']}_reaction_particle.h5"
+    model_particle_one.save()
+    data_particle_one = model_particle_one.run_simulation()
+    if data_particle_one.return_code != 0:
+        print(data_particle_one.return_code)
+    print(data_particle_one.error_message)
+
+    # new interface particle 2 reactions
+    case_particle_two = MRC.get_dict_two_reaction_mal()
+    model_particle_two = Cadet(cadet_path)
+    model_particle_two = MRC.lrmp_setup(model_particle_two)
+    model_particle_two = MRC.mal_setup_particle(model_particle_two, case_particle_two)
+    model_particle_two.filename = f"lrmp_{case_particle_two['num_reactions']}_reaction_particle.h5"
+    model_particle_two.save()
+    data_particle_two = model_particle_two.run_simulation()
+    if data_particle_two.return_code != 0:
+        print(data_particle_two.return_code)
+    print(data_particle_two.error_message)
+
+    # new interface particle 3 reactions 
+    case_particle_three = MRC.get_dict_three_reaction_mal()
+    model_particle_three = Cadet(cadet_path)
+    model_particle_three = MRC.lrmp_setup(model_particle_three)
+    model_particle_three = MRC.mal_setup_particle(model_particle_three, case_particle_three)
+    model_particle_three.filename = f"lrmp_{case_particle_three['num_reactions']}_reaction_particle.h5"
+    model_particle_three.save()
+    data_particle_three = model_particle_three.run_simulation()
+    if data_particle_three.return_code != 0:
+        print(data_particle_three.return_code)
+    print(data_particle_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_particle_one.root.output.solution.solution_times, model_particle_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 1 Reaction')
+        plt.plot(model_particle_two.root.output.solution.solution_times, model_particle_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 2 Reactions')
+        plt.plot(model_particle_three.root.output.solution.solution_times, model_particle_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('LRMP Multiple Particle Reactions Comparison')
+        #plt.savefig(output_path + '/lrmp_multiple_reactions_particle_comparison.png')
+        plt.show()
+    
+    # check max absolut error with tolerance
+    tolerance = 1e-10
+    max_error_1_2 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_two.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_2 < tolerance, f'  WARNING: Max error between 1 and 2 particle reactions ({max_error_1_2}) exceeds tolerance ({tolerance})'
+
+    max_error_1_3 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_3 < tolerance, f'  WARNING: Max error between 1 and 3 particle reactions ({max_error_1_3}) exceeds tolerance ({tolerance})'
+    
+    max_error_2_3 = np.max(np.abs(model_particle_two.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_2_3 < tolerance, f'  WARNING: Max error between 2 and 3 particle reactions ({max_error_2_3}) exceeds tolerance ({tolerance})'
 
 def multiple_reactions_lrmp_test_cross_phase(output_path, cadet_path, plot=False):
+
+     #old interface particle
+    case_particle_mal_old = MRC.get_dict_one_reaction_cross_phase()
+    model_particle_mal_old = Cadet(cadet_path)
+    model_particle_mal_old = MRC.lrmp_setup(model_particle_mal_old)
+    model_particle_mal_old = MRC.mal_setup_particle_old(model_particle_mal_old, case_particle_mal_old)
+    model_particle_mal_old.filename = f"lrmp_{case_particle_mal_old['num_reactions']}_reaction_particle_old.h5"
+    model_particle_mal_old.save()
+    data_particle_mal_old = model_particle_mal_old.run_simulation()
+    if data_particle_mal_old.return_code != 0:
+        print(data_particle_mal_old.return_code)
+    print(data_particle_mal_old.error_message)
     
     # new interface cross_phase 1 reaction
     case_cross_phase_one = MRC.get_dict_one_reaction_cross_phase()
@@ -291,7 +237,8 @@ def multiple_reactions_lrmp_test_cross_phase(output_path, cadet_path, plot=False
     model_cross_phase_one.filename = f"lrmp_{case_cross_phase_one['num_reactions']}_reaction_cross_phase.h5"
     model_cross_phase_one.save()
     data_cross_phase_one = model_cross_phase_one.run_simulation()
-    print(data_cross_phase_one.return_code)
+    if data_cross_phase_one.return_code != 0:
+        print(data_cross_phase_one.return_code)
     print(data_cross_phase_one.error_message)
 
     # new interface cross_phase 2 reactions
@@ -330,49 +277,126 @@ def multiple_reactions_lrmp_test_cross_phase(output_path, cadet_path, plot=False
         #plt.savefig(output_path + '/lrmp_multiple_reactions_cross_phase_comparison.png')
         plt.show()
     
-    # print max absolut error
+    # check max absolut error with tolerance
+    tolerance = 1e-10
     max_error_1_2 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_two.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 2 cross phase reactions: {max_error_1_2}')
+    assert max_error_1_2 < tolerance, f'  WARNING: Max error between 1 and 2 cross phase reactions ({max_error_1_2}) exceeds tolerance ({tolerance})'
 
     max_error_1_3 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 3 cross phase reactions: {max_error_1_3}')
+    assert max_error_1_3 < tolerance, f'  WARNING: Max error between 1 and 3 cross phase reactions ({max_error_1_3}) exceeds tolerance ({tolerance})'
     
     max_error_2_3 = np.max(np.abs(model_cross_phase_two.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 2 and 3 cross phase reactions: {max_error_2_3}')
+    assert max_error_2_3 < tolerance, f'  WARNING: Max error between 2 and 3 cross phase reactions ({max_error_2_3}) exceeds tolerance ({tolerance})'
 
+def multiple_reactions_grm_test_bulk(output_path, cadet_path, plot=False):
 
-def multiple_reactions_lrmp_test_particle(output_path, cadet_path, plot=False):
+    #old interface bulk
+    case_bulk_old = MRC.get_dict_one_reaction_mal()
+    model_bulk_old = Cadet(cadet_path)
+    model_bulk_old = MRC.grm_setup(model_bulk_old)
+    model_bulk_old = MRC.mal_setup_bulk_old(model_bulk_old, case_bulk_old)
+    model_bulk_old.filename = f"grm_{case_bulk_old['num_reactions']}_reaction_bulk_old.h5"
+    model_bulk_old.save()
+    data_bulk_old = model_bulk_old.run_simulation()
+    print(data_bulk_old.return_code)
+    print(data_bulk_old.error_message)
+
     
+    # new interface bulk 1 reaction
+    case_bulk_one = MRC.get_dict_one_reaction_mal()
+
+    model_bulk_one = Cadet(cadet_path)
+    model_bulk_one = MRC.grm_setup(model_bulk_one)
+    model_bulk_one = MRC.mal_setup_bulk(model_bulk_one, case_bulk_one)
+    model_bulk_one.filename = f"grm_{case_bulk_one['num_reactions']}_reaction_bulk.h5"
+    model_bulk_one.save()
+    data_bulk_one = model_bulk_one.run_simulation()
+    print(data_bulk_one.return_code)
+    print(data_bulk_one.error_message)
+
+    # new interface bulk 2 reactions
+    case_bulk_two = MRC.get_dict_two_reaction_mal()
+    model_bulk_two = Cadet(cadet_path)
+    model_bulk_two = MRC.grm_setup(model_bulk_two)
+    model_bulk_two = MRC.mal_setup_bulk(model_bulk_two, case_bulk_two)
+    model_bulk_two.filename = f"grm_{case_bulk_two['num_reactions']}_reaction_bulk.h5"
+    model_bulk_two.save()
+    data_bulk_two = model_bulk_two.run_simulation()
+    print(data_bulk_two.return_code)
+    print(data_bulk_two.error_message)
+
+    # new interface bulk 3 reactions
+    case_bulk_three = MRC.get_dict_three_reaction_mal()
+    model_bulk_three = Cadet(cadet_path)
+    model_bulk_three = MRC.grm_setup(model_bulk_three)
+    model_bulk_three = MRC.mal_setup_bulk(model_bulk_three, case_bulk_three)
+    model_bulk_three.filename = f"grm_{case_bulk_three['num_reactions']}_reaction_bulk.h5"
+    model_bulk_three.save()
+    data_bulk_three = model_bulk_three.run_simulation()
+    print(data_bulk_three.return_code)
+    print(data_bulk_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_bulk_one.root.output.solution.solution_times, model_bulk_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Bulk - 1 Reaction')
+        plt.plot(model_bulk_two.root.output.solution.solution_times, model_bulk_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Bulk - 2 Reactions')
+        plt.plot(model_bulk_three.root.output.solution.solution_times, model_bulk_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Bulk - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('GRM Multiple Bulk Reactions Comparison')
+        #plt.savefig(output_path + '/grm_multiple_reactions_bulk_comparison.png')
+        plt.show()
+
+    # check max absolute error with tolerance
+    tolerance = 1e-10
+    max_error_1_2 = np.max(np.abs(model_bulk_one.root.output.solution.unit_000.solution_bulk - model_bulk_two.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_2 < tolerance, f'  WARNING: Max error between 1 and 2 bulk reactions ({max_error_1_2}) exceeds tolerance ({tolerance})'
+
+    max_error_1_3 = np.max(np.abs(model_bulk_one.root.output.solution.unit_000.solution_bulk - model_bulk_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_3 < tolerance, f'  WARNING: Max error between 1 and 3 bulk reactions ({max_error_1_3}) exceeds tolerance ({tolerance})'
+
+    max_error_2_3 = np.max(np.abs(model_bulk_two.root.output.solution.unit_000.solution_bulk - model_bulk_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_2_3 < tolerance, f'  WARNING: Max error between 2 and 3 bulk reactions ({max_error_2_3}) exceeds tolerance ({tolerance})'
+
+    # compare with old interface
+    max_error_old_1 = np.max(np.abs(model_bulk_old.root.output.solution.unit_000.solution_bulk - model_bulk_one.root.output.solution.unit_000.solution_bulk))
+    assert max_error_old_1 < tolerance, f'  WARNING: Max error between old and new interface for 1 reaction ({max_error_old_1}) exceeds tolerance ({tolerance})'
+
+def multiple_reactions_grm_test_particle(output_path, cadet_path, plot=False):
+
     # new interface particle 1 reaction
-    case_particle_one = MRC.get_dict_one_reaction_particle()
-    
+    case_particle_one = MRC.get_dict_one_reaction_mal()
+
     model_particle_one = Cadet(cadet_path)
-    model_particle_one = MRC.lrmp_setup(model_particle_one)
-    model_particle_one = MRC.mal_setup_paricle(model_particle_one, case_particle_one)
-    
-    model_particle_one.filename = f"lrmp_{case_particle_one['num_reactions']}_reaction_particle.h5"
+    model_particle_one = MRC.grm_setup(model_particle_one)
+    model_particle_one = MRC.mal_setup_particle(model_particle_one, case_particle_one)
+
+    model_particle_one.filename = f"grm_{case_particle_one['num_reactions']}_reaction_particle.h5"
     model_particle_one.save()
     data_particle_one = model_particle_one.run_simulation()
     print(data_particle_one.return_code)
     print(data_particle_one.error_message)
 
     # new interface particle 2 reactions
-    case_particle_two = MRC.get_dict_two_reactions_particle()
+    case_particle_two = MRC.get_dict_two_reaction_mal()
     model_particle_two = Cadet(cadet_path)
-    model_particle_two = MRC.lrmp_setup(model_particle_two)
-    model_particle_two = MRC.mal_setup_paricle(model_particle_two, case_particle_two)
-    model_particle_two.filename = f"lrmp_{case_particle_two['num_reactions']}_reaction_particle.h5"
+    model_particle_two = MRC.grm_setup(model_particle_two)
+    model_particle_two = MRC.mal_setup_particle(model_particle_two, case_particle_two)
+    model_particle_two.filename = f"grm_{case_particle_two['num_reactions']}_reaction_particle.h5"
     model_particle_two.save()
     data_particle_two = model_particle_two.run_simulation()
     print(data_particle_two.return_code)
     print(data_particle_two.error_message)
 
-    # new interface particle 3 reactions 
-    case_particle_three = MRC.get_dict_three_reactions_particle()
+    # new interface particle 3 reactions
+    case_particle_three = MRC.get_dict_three_reaction_mal()
     model_particle_three = Cadet(cadet_path)
-    model_particle_three = MRC.lrmp_setup(model_particle_three)
-    model_particle_three = MRC.mal_setup_paricle(model_particle_three, case_particle_three)
-    model_particle_three.filename = f"lrmp_{case_particle_three['num_reactions']}_reaction_particle.h5"
+    model_particle_three = MRC.grm_setup(model_particle_three)
+    model_particle_three = MRC.mal_setup_particle(model_particle_three, case_particle_three)
+    model_particle_three.filename = f"grm_{case_particle_three['num_reactions']}_reaction_particle.h5"
     model_particle_three.save()
     data_particle_three = model_particle_three.run_simulation()
     print(data_particle_three.return_code)
@@ -388,18 +412,230 @@ def multiple_reactions_lrmp_test_particle(output_path, cadet_path, plot=False):
         plt.xlabel('Time')
         plt.ylabel('Concentration')
         plt.legend()
-        plt.title('LRMP Multiple Particle Reactions Comparison')
-        #plt.savefig(output_path + '/lrmp_multiple_reactions_particle_comparison.png')
+        plt.title('GRM Multiple Particle Reactions Comparison')
+        #plt.savefig(output_path + '/grm_multiple_reactions_particle_comparison.png')
         plt.show()
-    
-    # print max absolut error
+
+    # check max absolut error with tolerance
+    tolerance = 1e-10
     max_error_1_2 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_two.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 2 particle reactions: {max_error_1_2}')
+    assert max_error_1_2 < tolerance, f'  WARNING: Max error between 1 and 2 particle reactions ({max_error_1_2}) exceeds tolerance ({tolerance})'
 
     max_error_1_3 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 1 and 3 particle reactions: {max_error_1_3}')
-    
+    assert max_error_1_3 < tolerance, f'  WARNING: Max error between 1 and 3 particle reactions ({max_error_1_3}) exceeds tolerance ({tolerance})'
+
     max_error_2_3 = np.max(np.abs(model_particle_two.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
-    print(f'Max absolute error between 2 and 3 particle reactions: {max_error_2_3}')
+    assert max_error_2_3 < tolerance, f'  WARNING: Max error between 2 and 3 particle reactions ({max_error_2_3}) exceeds tolerance ({tolerance})'
 
+def multiple_reactions_grm_test_cross_phase(output_path, cadet_path, plot=False):
 
+    # new interface cross_phase 1 reaction
+    case_cross_phase_one = MRC.get_dict_one_reaction_cross_phase()
+
+    model_cross_phase_one = Cadet(cadet_path)
+    model_cross_phase_one = MRC.grm_setup(model_cross_phase_one)
+    model_cross_phase_one = MRC.mal_setup_cross_phase(model_cross_phase_one, case_cross_phase_one)
+
+    model_cross_phase_one.filename = f"grm_{case_cross_phase_one['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_one.save()
+    data_cross_phase_one = model_cross_phase_one.run_simulation()
+    print(data_cross_phase_one.return_code)
+    print(data_cross_phase_one.error_message)
+
+    # new interface cross_phase 2 reactions
+    case_cross_phase_two = MRC.get_dict_two_reactions_cross_phase()
+    model_cross_phase_two = Cadet(cadet_path)
+    model_cross_phase_two = MRC.grm_setup(model_cross_phase_two)
+    model_cross_phase_two = MRC.mal_setup_cross_phase(model_cross_phase_two, case_cross_phase_two)
+    model_cross_phase_two.filename = f"grm_{case_cross_phase_two['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_two.save()
+    data_cross_phase_two = model_cross_phase_two.run_simulation()
+    print(data_cross_phase_two.return_code)
+    print(data_cross_phase_two.error_message)
+
+    # new interface cross_phase 3 reactions
+    case_cross_phase_three = MRC.get_dict_three_reactions_cross_phase()
+    model_cross_phase_three = Cadet(cadet_path)
+    model_cross_phase_three = MRC.grm_setup(model_cross_phase_three)
+    model_cross_phase_three = MRC.mal_setup_cross_phase(model_cross_phase_three, case_cross_phase_three)
+    model_cross_phase_three.filename = f"grm_{case_cross_phase_three['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_three.save()
+    data_cross_phase_three = model_cross_phase_three.run_simulation()
+    print(data_cross_phase_three.return_code)
+    print(data_cross_phase_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_cross_phase_one.root.output.solution.solution_times, model_cross_phase_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 1 Reaction')
+        plt.plot(model_cross_phase_two.root.output.solution.solution_times, model_cross_phase_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 2 Reactions')
+        plt.plot(model_cross_phase_three.root.output.solution.solution_times, model_cross_phase_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('GRM Multiple Cross Phase Reactions Comparison')
+        #plt.savefig(output_path + '/grm_multiple_reactions_cross_phase_comparison.png')
+        plt.show()
+
+    # print max absolut error
+    max_error_1_2 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_two.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 2 cross phase reactions: {max_error_1_2}')
+
+    max_error_1_3 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 3 cross phase reactions: {max_error_1_3}')
+
+    max_error_2_3 = np.max(np.abs(model_cross_phase_two.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 2 and 3 cross phase reactions: {max_error_2_3}')
+
+def multiple_reactions_lrm_cross_phase_test(output_path, cadet_path, plot=False):
+
+    
+    # new interface cross_phase 1 reaction
+    case_cross_phase_one = MRC.get_dict_one_reaction_cross_phase()
+
+    model_cross_phase_one = Cadet(cadet_path)
+    model_cross_phase_one = MRC.lrm_setup(model_cross_phase_one)
+    model_cross_phase_one = MRC.mal_setup_cross_phase(model_cross_phase_one, case_cross_phase_one)
+
+    model_cross_phase_one.filename = f"lrm_{case_cross_phase_one['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_one.save()
+    data_cross_phase_one = model_cross_phase_one.run_simulation()
+    print(data_cross_phase_one.return_code)
+    print(data_cross_phase_one.error_message)
+
+    # new interface cross_phase 2 reactions
+    case_cross_phase_two = MRC.get_dict_two_reactions_cross_phase()
+    model_cross_phase_two = Cadet(cadet_path)
+    model_cross_phase_two = MRC.lrm_setup(model_cross_phase_two)
+    model_cross_phase_two = MRC.mal_setup_cross_phase(model_cross_phase_two, case_cross_phase_two)
+    model_cross_phase_two.filename = f"lrm_{case_cross_phase_two['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_two.save()
+    data_cross_phase_two = model_cross_phase_two.run_simulation()
+    print(data_cross_phase_two.return_code)
+    print(data_cross_phase_two.error_message)
+
+    # new interface cross_phase 3 reactions
+    case_cross_phase_three = MRC.get_dict_three_reactions_cross_phase()
+    model_cross_phase_three = Cadet(cadet_path)
+    model_cross_phase_three = MRC.lrm_setup(model_cross_phase_three)
+    model_cross_phase_three = MRC.mal_setup_cross_phase(model_cross_phase_three, case_cross_phase_three)
+    model_cross_phase_three.filename = f"lrm_{case_cross_phase_three['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_three.save()
+    data_cross_phase_three = model_cross_phase_three.run_simulation()
+    print(data_cross_phase_three.return_code)
+    print(data_cross_phase_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_cross_phase_one.root.output.solution.solution_times, model_cross_phase_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 1 Reaction')
+        plt.plot(model_cross_phase_two.root.output.solution.solution_times, model_cross_phase_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 2 Reactions')
+        plt.plot(model_cross_phase_three.root.output.solution.solution_times, model_cross_phase_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('LRM Multiple Cross Phase Reactions Comparison')
+        #plt.savefig(output_path + '/lrm_multiple_reactions_cross_phase_comparison.png')
+        plt.show()
+
+    # check max absolut error with tolerance
+    tolerance = 1e-10
+    max_error_1_2 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_two.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_2 < tolerance, f'  WARNING: Max error between 1 and 2 cross phase reactions ({max_error_1_2}) exceeds tolerance ({tolerance})'
+
+    max_error_1_3 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_3 < tolerance, f'  WARNING: Max error between 1 and 3 cross phase reactions ({max_error_1_3}) exceeds tolerance ({tolerance})'
+
+    max_error_2_3 = np.max(np.abs(model_cross_phase_two.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_2_3 < tolerance, f'  WARNING: Max error between 2 and 3 cross phase reactions ({max_error_2_3}) exceeds tolerance ({tolerance})'
+
+def multiple_reactions_mct_test_bulk(output_path, cadet_path, plot=False):
+    
+    # old interface bulk 
+    case_bulk_old = MRC.get_dict_one_reaction_mal()
+    model_bulk_old = Cadet(cadet_path)
+    model_bulk_old = MRC.mct_setup(model_bulk_old)
+    model_bulk_old = MRC.mal_setup_bulk_old(model_bulk_old, case_bulk_old)
+    model_bulk_old.filename = f"mct_{case_bulk_old['num_reactions']}_reaction_bulk_old.h5"
+    model_bulk_old.save()
+    data_bulk_old = model_bulk_old.run_simulation()
+    print(data_bulk_old.return_code)
+    print(data_bulk_old.error_message)
+    
+    case_bulk_one = MRC.get_dict_one_reaction_mal()
+
+    model_bulk_one = Cadet(cadet_path)
+    model_bulk_one = MRC.mct_setup(model_bulk_one)
+    model_bulk_one = MRC.mal_setup_bulk(model_bulk_one, case_bulk_one)
+    model_bulk_one.filename = f"mct_{case_bulk_one['num_reactions']}_reaction_bulk.h5"
+    model_bulk_one.save()
+    data_bulk_one = model_bulk_one.run_simulation()
+    print(data_bulk_one.return_code)
+    print(data_bulk_one.error_message)
+
+    # new interface bulk 2 reactions
+    case_bulk_two = MRC.get_dict_two_reaction_mal()
+    model_bulk_two = Cadet(cadet_path)
+    model_bulk_two = MRC.mct_setup(model_bulk_two)
+    model_bulk_two = MRC.mal_setup_bulk(model_bulk_two, case_bulk_two)
+    model_bulk_two.filename = f"mct_{case_bulk_two['num_reactions']}_reaction_bulk.h5"
+    model_bulk_two.save()
+    data_bulk_two = model_bulk_two.run_simulation()
+    print(data_bulk_two.return_code)
+    print(data_bulk_two.error_message)
+
+    # new interface bulk 3 reactions
+    case_bulk_three = MRC.get_dict_three_reaction_mal()
+    model_bulk_three = Cadet(cadet_path)
+    model_bulk_three = MRC.mct_setup(model_bulk_three)
+    model_bulk_three = MRC.mal_setup_bulk(model_bulk_three, case_bulk_three)
+    model_bulk_three.filename = f"mct_{case_bulk_three['num_reactions']}_reaction_bulk.h5"
+    model_bulk_three.save()
+    data_bulk_three = model_bulk_three.run_simulation()
+    print(data_bulk_three.return_code)
+    print(data_bulk_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_bulk_one.root.output.solution.solution_times, model_bulk_one.root.output.solution.unit_000.solution_bulk[:, 0, 0], label='Bulk - 1 Reaction')
+        plt.plot(model_bulk_two.root.output.solution.solution_times, model_bulk_two.root.output.solution.unit_000.solution_bulk[:,0, 0], label='Bulk - 2 Reactions')
+        plt.plot(model_bulk_three.root.output.solution.solution_times, model_bulk_three.root.output.solution.unit_000.solution_bulk[:, 0,0], label='Bulk - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('MCT Multiple Bulk Reactions Comparison')
+        #plt.savefig(output_path + '/mct_multiple_reactions_bulk_comparison.png')
+        plt.show()
+
+    # check max absolute error with tolerance
+    tolerance = 1e-10
+    max_error_1_2 = np.max(np.abs(model_bulk_one.root.output.solution.unit_000.solution_bulk - model_bulk_two.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_2 < tolerance, f'  WARNING: Max error between 1 and 2 bulk reactions ({max_error_1_2}) exceeds tolerance ({tolerance})'
+
+    max_error_1_3 = np.max(np.abs(model_bulk_one.root.output.solution.unit_000.solution_bulk - model_bulk_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_1_3 < tolerance, f'  WARNING: Max error between 1 and 3 bulk reactions ({max_error_1_3}) exceeds tolerance ({tolerance})'
+
+    max_error_2_3 = np.max(np.abs(model_bulk_two.root.output.solution.unit_000.solution_bulk - model_bulk_three.root.output.solution.unit_000.solution_bulk))
+    assert max_error_2_3 < tolerance, f'  WARNING: Max error between 2 and 3 bulk reactions ({max_error_2_3}) exceeds tolerance ({tolerance})'
+
+    # compare old and new interface
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_bulk_old.root.output.solution.solution_times, model_bulk_old.root.output.solution.unit_000.solution_bulk[:, 0, 0], label='Old Interface - Bulk - 1 Reaction')
+        plt.plot(model_bulk_one.root.output.solution.solution_times, model_bulk_one.root.output.solution.unit_000.solution_bulk[:, 0, 0], label='New Interface - Bulk - 1 Reaction')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('MCT Old vs New Interface Bulk Reactions Comparison')
+        #plt.savefig(output_path + '/mct_old_vs_new_interface_bulk_comparison.png')
+        plt.show()
+
+    # compare old and new interface with tolerance
+    tolerance = 1e-10
+    max_error_old_new = np.max(np.abs(model_bulk_old.root.output.solution.unit_000.solution_bulk - model_bulk_one.root.output.solution.unit_000.solution_bulk))
+    assert max_error_old_new < tolerance, f'  WARNING: Max error between old and new interface for 1 reaction ({max_error_old_new}) exceeds tolerance ({tolerance})'

--- a/src/multiple_reactions.py
+++ b/src/multiple_reactions.py
@@ -1,0 +1,405 @@
+import numpy as np
+from cadet import Cadet
+import multiple_reaction_configs as MRC
+
+
+def multiple_reactions_cstr_test_bulk(output_path, cadet_path, plot=False):
+    
+    # old interface bulk
+    case_bulk_mal_old = MRC.get_dict_one_reaction_mal()
+    
+    model_bulk_mal_old = Cadet(cadet_path)
+    model_bulk_mal_old = MRC.cstr_setup(model_bulk_mal_old)
+    model_bulk_mal_old = MRC.mal_setup_bulk_old(model_bulk_mal_old,case_bulk_mal_old)
+    
+    model_bulk_mal_old.filename = f"cstr_{case_bulk_mal_old['num_reactions']}_reaction_old.h5"
+    model_bulk_mal_old.save()
+    data_bulk_mal_old = model_bulk_mal_old.run_simulation()
+    print(data_bulk_mal_old.return_code)
+    print(data_bulk_mal_old.error_message)
+
+
+    # new interface bulk 1 reaction
+    case_bulk_mal_one = MRC.get_dict_one_reaction_mal()
+    
+    model_bulk_mal_one = Cadet(cadet_path)
+    model_bulk_mal_one = MRC.cstr_setup(model_bulk_mal_one)
+    model_bulk_mal_one = MRC.mal_setup_bulk(model_bulk_mal_one, case_bulk_mal_one)
+    model_bulk_mal_one.filename = f"cstr_{case_bulk_mal_one['num_reactions']}_reaction_new.h5"
+    model_bulk_mal_one.save()
+    data_bulk_mal_one = model_bulk_mal_one.run_simulation()
+    print(data_bulk_mal_one.return_code)
+    print(data_bulk_mal_one.error_message)
+
+    # new interface bulk 2 reactions
+    case_bulk_mal_two = MRC.get_dict_two_reaction_mal()
+    model_bulk_mal_two = Cadet(cadet_path)
+    model_bulk_mal_two = MRC.cstr_setup(model_bulk_mal_two)
+    model_bulk_mal_two = MRC.mal_setup_bulk(model_bulk_mal_two, case_bulk_mal_two)
+    model_bulk_mal_two.filename = f"cstr_{case_bulk_mal_two['num_reactions']}_reaction_new.h5"
+    model_bulk_mal_two.save()
+    data_bulk_mal_two = model_bulk_mal_two.run_simulation()
+    print(data_bulk_mal_two.return_code)
+    print(data_bulk_mal_two.error_message)
+
+    # new interface bulk 3 reactions 
+    case_bulk_mal_three = MRC.get_dict_three_reaction_mal()
+    model_bulk_mal_three = Cadet(cadet_path)
+    model_bulk_mal_three = MRC.cstr_setup(model_bulk_mal_three)
+    model_bulk_mal_three = MRC.mal_setup_bulk(model_bulk_mal_three, case_bulk_mal_three)
+    model_bulk_mal_three.filename = f"cstr_{case_bulk_mal_three['num_reactions']}_reaction_new.h5"
+    model_bulk_mal_three.save()
+    data_bulk_mal_three = model_bulk_mal_three.run_simulation()
+    print(data_bulk_mal_three.return_code)
+    print(data_bulk_mal_three.error_message)
+
+    # compare results
+
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_bulk_mal_old.root.output.solution.solution_times, model_bulk_mal_old.root.output.solution.unit_000.solution_bulk, label='Old Interface - Reaction 1')
+        plt.plot(model_bulk_mal_one.root.output.solution.solution_times, model_bulk_mal_one.root.output.solution.unit_000.solution_bulk, label='New Interface - Reaction 1')
+        plt.plot(model_bulk_mal_two.root.output.solution.solution_times, model_bulk_mal_two.root.output.solution.unit_000.solution_bulk, label='New Interface - Reaction 2')
+        plt.plot(model_bulk_mal_three.root.output.solution.solution_times, model_bulk_mal_three.root.output.solution.unit_000.solution_bulk[:, 0], label='New Interface - Reaction 3')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('CSTR Multiple Reactions Comparison')
+        #plt.savefig(output_path + '/cstr_multiple_reactions_bulk_comparison.png')
+        plt.show()
+    
+    # print max absolut error
+    max_error_1 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_one.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between old and new interface for 1 reaction: {max_error_1}')
+
+    max_error_2 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_two.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between old and new interface for 2 reactions: {max_error_2}')
+    
+    max_error_3 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between old and new interface for 3 reactions: {max_error_3}')
+
+
+def multiple_reactions_cstr_test_cross_phase(output_path, cadet_path, plot=False):
+    
+    # new interface cross_phase 1 reaction
+    case_cross_phase_one = MRC.get_dict_one_reaction_cross_phase()
+    
+    model_cross_phase_one = Cadet(cadet_path)
+    model_cross_phase_one = MRC.lrmp_setup(model_cross_phase_one)
+    model_cross_phase_one = MRC.mal_setup_cross_phase(model_cross_phase_one, case_cross_phase_one)
+    
+    model_cross_phase_one.filename = f"lrmp_{case_cross_phase_one['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_one.save()
+    data_cross_phase_one = model_cross_phase_one.run_simulation()
+    print(data_cross_phase_one.return_code)
+    print(data_cross_phase_one.error_message)
+
+    # new interface cross_phase 2 reactions
+    case_cross_phase_two = MRC.get_dict_two_reactions_cross_phase()
+    model_cross_phase_two = Cadet(cadet_path)
+    model_cross_phase_two = MRC.lrmp_setup(model_cross_phase_two)
+    model_cross_phase_two = MRC.mal_setup_cross_phase(model_cross_phase_two, case_cross_phase_two)
+    model_cross_phase_two.filename = f"lrmp_{case_cross_phase_two['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_two.save()
+    data_cross_phase_two = model_cross_phase_two.run_simulation()
+    print(data_cross_phase_two.return_code)
+    print(data_cross_phase_two.error_message)
+
+    # new interface cross_phase 3 reactions 
+    case_cross_phase_three = MRC.get_dict_three_reactions_cross_phase()
+    model_cross_phase_three = Cadet(cadet_path)
+    model_cross_phase_three = MRC.lrmp_setup(model_cross_phase_three)
+    model_cross_phase_three = MRC.mal_setup_cross_phase(model_cross_phase_three, case_cross_phase_three)
+    model_cross_phase_three.filename = f"lrmp_{case_cross_phase_three['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_three.save()
+    data_cross_phase_three = model_cross_phase_three.run_simulation()
+    print(data_cross_phase_three.return_code)
+    print(data_cross_phase_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_cross_phase_one.root.output.solution.solution_times, model_cross_phase_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 1 Reaction')
+        plt.plot(model_cross_phase_two.root.output.solution.solution_times, model_cross_phase_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 2 Reactions')
+        plt.plot(model_cross_phase_three.root.output.solution.solution_times, model_cross_phase_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('LRMP Multiple Cross Phase Reactions Comparison')
+        #plt.savefig(output_path + '/lrmp_multiple_reactions_cross_phase_comparison.png')
+        plt.show()
+    
+    # print max absolut error
+    max_error_1_2 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_two.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 2 cross phase reactions: {max_error_1_2}')
+
+    max_error_1_3 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 3 cross phase reactions: {max_error_1_3}')
+    
+    max_error_2_3 = np.max(np.abs(model_cross_phase_two.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 2 and 3 cross phase reactions: {max_error_2_3}')
+
+
+def multiple_reactions_cstr_test_particle(output_path, cadet_path, plot=False):
+    
+    # new interface particle 1 reaction
+    case_particle_one = MRC.get_dict_one_reaction_particle()
+    
+    model_particle_one = Cadet(cadet_path)
+    model_particle_one = MRC.lrmp_setup(model_particle_one)
+    model_particle_one = MRC.mal_setup_paricle(model_particle_one, case_particle_one)
+    
+    model_particle_one.filename = f"lrmp_{case_particle_one['num_reactions']}_reaction_particle.h5"
+    model_particle_one.save()
+    data_particle_one = model_particle_one.run_simulation()
+    print(data_particle_one.return_code)
+    print(data_particle_one.error_message)
+
+    # new interface particle 2 reactions
+    case_particle_two = MRC.get_dict_two_reactions_particle()
+    model_particle_two = Cadet(cadet_path)
+    model_particle_two = MRC.lrmp_setup(model_particle_two)
+    model_particle_two = MRC.mal_setup_paricle(model_particle_two, case_particle_two)
+    model_particle_two.filename = f"lrmp_{case_particle_two['num_reactions']}_reaction_particle.h5"
+    model_particle_two.save()
+    data_particle_two = model_particle_two.run_simulation()
+    print(data_particle_two.return_code)
+    print(data_particle_two.error_message)
+
+    # new interface particle 3 reactions 
+    case_particle_three = MRC.get_dict_three_reactions_particle()
+    model_particle_three = Cadet(cadet_path)
+    model_particle_three = MRC.lrmp_setup(model_particle_three)
+    model_particle_three = MRC.mal_setup_paricle(model_particle_three, case_particle_three)
+    model_particle_three.filename = f"lrmp_{case_particle_three['num_reactions']}_reaction_particle.h5"
+    model_particle_three.save()
+    data_particle_three = model_particle_three.run_simulation()
+    print(data_particle_three.return_code)
+    print(data_particle_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_particle_one.root.output.solution.solution_times, model_particle_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 1 Reaction')
+        plt.plot(model_particle_two.root.output.solution.solution_times, model_particle_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 2 Reactions')
+        plt.plot(model_particle_three.root.output.solution.solution_times, model_particle_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('LRMP Multiple Particle Reactions Comparison')
+        #plt.savefig(output_path + '/lrmp_multiple_reactions_particle_comparison.png')
+        plt.show()
+    
+    # print max absolut error
+    max_error_1_2 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_two.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 2 particle reactions: {max_error_1_2}')
+
+    max_error_1_3 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 3 particle reactions: {max_error_1_3}')
+    
+    max_error_2_3 = np.max(np.abs(model_particle_two.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 2 and 3 particle reactions: {max_error_2_3}')
+
+
+def multiple_reactions_lrmp_test_bulk(output_path, cadet_path, plot=False):
+    
+    # old interface bulk
+    case_bulk_mal_old = MRC.get_dict_one_reaction_mal()
+    
+    model_bulk_mal_old = Cadet(cadet_path)
+    model_bulk_mal_old = MRC.lrmp_setup(model_bulk_mal_old)
+    model_bulk_mal_old = MRC.mal_setup_bulk_old(model_bulk_mal_old, case_bulk_mal_old)
+    
+    model_bulk_mal_old.filename = f"lrmp_{case_bulk_mal_old['num_reactions']}_reaction_bulk_old.h5"
+    model_bulk_mal_old.save()
+    data_bulk_mal_old = model_bulk_mal_old.run_simulation()
+    print(data_bulk_mal_old.return_code)
+    print(data_bulk_mal_old.error_message)
+
+    # new interface bulk 1 reaction
+    case_bulk_mal_one = MRC.get_dict_one_reaction_mal()
+    
+    model_bulk_mal_one = Cadet(cadet_path)
+    model_bulk_mal_one = MRC.lrmp_setup(model_bulk_mal_one)
+    model_bulk_mal_one = MRC.mal_setup_bulk(model_bulk_mal_one, case_bulk_mal_one)
+    model_bulk_mal_one.filename = f"lrmp_{case_bulk_mal_one['num_reactions']}_reaction_bulk_new.h5"
+    model_bulk_mal_one.save()
+    data_bulk_mal_one = model_bulk_mal_one.run_simulation()
+    print(data_bulk_mal_one.return_code)
+    print(data_bulk_mal_one.error_message)
+
+    # new interface bulk 2 reactions
+    case_bulk_mal_two = MRC.get_dict_two_reactions_mal()
+    model_bulk_mal_two = Cadet(cadet_path)
+    model_bulk_mal_two = MRC.lrmp_setup(model_bulk_mal_two)
+    model_bulk_mal_two = MRC.mal_setup_bulk(model_bulk_mal_two, case_bulk_mal_two)
+    model_bulk_mal_two.filename = f"lrmp_{case_bulk_mal_two['num_reactions']}_reaction_bulk_new.h5"
+    model_bulk_mal_two.save()
+    data_bulk_mal_two = model_bulk_mal_two.run_simulation()
+    print(data_bulk_mal_two.return_code)
+    print(data_bulk_mal_two.error_message)
+
+    # new interface bulk 3 reactions 
+    case_bulk_mal_three = MRC.get_dict_three_reactions_mal()
+    model_bulk_mal_three = Cadet(cadet_path)
+    model_bulk_mal_three = MRC.lrmp_setup(model_bulk_mal_three)
+    model_bulk_mal_three = MRC.mal_setup_bulk(model_bulk_mal_three, case_bulk_mal_three)
+    model_bulk_mal_three.filename = f"lrmp_{case_bulk_mal_three['num_reactions']}_reaction_bulk_new.h5"
+    model_bulk_mal_three.save()
+    data_bulk_mal_three = model_bulk_mal_three.run_simulation()
+    print(data_bulk_mal_three.return_code)
+    print(data_bulk_mal_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_bulk_mal_old.root.output.solution.solution_times, model_bulk_mal_old.root.output.solution.unit_000.solution_bulk[:, 0], label='Old Interface - Reaction 1')
+        plt.plot(model_bulk_mal_one.root.output.solution.solution_times, model_bulk_mal_one.root.output.solution.unit_000.solution_bulk[:, 0], label='New Interface - Reaction 1')
+        plt.plot(model_bulk_mal_two.root.output.solution.solution_times, model_bulk_mal_two.root.output.solution.unit_000.solution_bulk[:, 0], label='New Interface - Reaction 2')
+        plt.plot(model_bulk_mal_three.root.output.solution.solution_times, model_bulk_mal_three.root.output.solution.unit_000.solution_bulk[:, 0], label='New Interface - Reaction 3')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('LRMP Multiple Bulk Reactions Comparison')
+        #plt.savefig(output_path + '/lrmp_multiple_reactions_bulk_comparison.png')
+        plt.show()
+    
+    # print max absolut error
+    max_error_1 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_one.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between old and new interface for 1 reaction: {max_error_1}')
+
+    max_error_2 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_two.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between old and new interface for 2 reactions: {max_error_2}')
+    
+    max_error_3 = np.max(np.abs(model_bulk_mal_old.root.output.solution.unit_000.solution_bulk - model_bulk_mal_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between old and new interface for 3 reactions: {max_error_3}')
+
+
+def multiple_reactions_lrmp_test_cross_phase(output_path, cadet_path, plot=False):
+    
+    # new interface cross_phase 1 reaction
+    case_cross_phase_one = MRC.get_dict_one_reaction_cross_phase()
+    
+    model_cross_phase_one = Cadet(cadet_path)
+    model_cross_phase_one = MRC.lrmp_setup(model_cross_phase_one)
+    model_cross_phase_one = MRC.mal_setup_cross_phase(model_cross_phase_one, case_cross_phase_one)
+    
+    model_cross_phase_one.filename = f"lrmp_{case_cross_phase_one['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_one.save()
+    data_cross_phase_one = model_cross_phase_one.run_simulation()
+    print(data_cross_phase_one.return_code)
+    print(data_cross_phase_one.error_message)
+
+    # new interface cross_phase 2 reactions
+    case_cross_phase_two = MRC.get_dict_two_reactions_cross_phase()
+    model_cross_phase_two = Cadet(cadet_path)
+    model_cross_phase_two = MRC.lrmp_setup(model_cross_phase_two)
+    model_cross_phase_two = MRC.mal_setup_cross_phase(model_cross_phase_two, case_cross_phase_two)
+    model_cross_phase_two.filename = f"lrmp_{case_cross_phase_two['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_two.save()
+    data_cross_phase_two = model_cross_phase_two.run_simulation()
+    print(data_cross_phase_two.return_code)
+    print(data_cross_phase_two.error_message)
+
+    # new interface cross_phase 3 reactions 
+    case_cross_phase_three = MRC.get_dict_three_reactions_cross_phase()
+    model_cross_phase_three = Cadet(cadet_path)
+    model_cross_phase_three = MRC.lrmp_setup(model_cross_phase_three)
+    model_cross_phase_three = MRC.mal_setup_cross_phase(model_cross_phase_three, case_cross_phase_three)
+    model_cross_phase_three.filename = f"lrmp_{case_cross_phase_three['num_reactions']}_reaction_cross_phase.h5"
+    model_cross_phase_three.save()
+    data_cross_phase_three = model_cross_phase_three.run_simulation()
+    print(data_cross_phase_three.return_code)
+    print(data_cross_phase_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_cross_phase_one.root.output.solution.solution_times, model_cross_phase_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 1 Reaction')
+        plt.plot(model_cross_phase_two.root.output.solution.solution_times, model_cross_phase_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 2 Reactions')
+        plt.plot(model_cross_phase_three.root.output.solution.solution_times, model_cross_phase_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Cross Phase - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('LRMP Multiple Cross Phase Reactions Comparison')
+        #plt.savefig(output_path + '/lrmp_multiple_reactions_cross_phase_comparison.png')
+        plt.show()
+    
+    # print max absolut error
+    max_error_1_2 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_two.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 2 cross phase reactions: {max_error_1_2}')
+
+    max_error_1_3 = np.max(np.abs(model_cross_phase_one.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 3 cross phase reactions: {max_error_1_3}')
+    
+    max_error_2_3 = np.max(np.abs(model_cross_phase_two.root.output.solution.unit_000.solution_bulk - model_cross_phase_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 2 and 3 cross phase reactions: {max_error_2_3}')
+
+
+def multiple_reactions_lrmp_test_particle(output_path, cadet_path, plot=False):
+    
+    # new interface particle 1 reaction
+    case_particle_one = MRC.get_dict_one_reaction_particle()
+    
+    model_particle_one = Cadet(cadet_path)
+    model_particle_one = MRC.lrmp_setup(model_particle_one)
+    model_particle_one = MRC.mal_setup_paricle(model_particle_one, case_particle_one)
+    
+    model_particle_one.filename = f"lrmp_{case_particle_one['num_reactions']}_reaction_particle.h5"
+    model_particle_one.save()
+    data_particle_one = model_particle_one.run_simulation()
+    print(data_particle_one.return_code)
+    print(data_particle_one.error_message)
+
+    # new interface particle 2 reactions
+    case_particle_two = MRC.get_dict_two_reactions_particle()
+    model_particle_two = Cadet(cadet_path)
+    model_particle_two = MRC.lrmp_setup(model_particle_two)
+    model_particle_two = MRC.mal_setup_paricle(model_particle_two, case_particle_two)
+    model_particle_two.filename = f"lrmp_{case_particle_two['num_reactions']}_reaction_particle.h5"
+    model_particle_two.save()
+    data_particle_two = model_particle_two.run_simulation()
+    print(data_particle_two.return_code)
+    print(data_particle_two.error_message)
+
+    # new interface particle 3 reactions 
+    case_particle_three = MRC.get_dict_three_reactions_particle()
+    model_particle_three = Cadet(cadet_path)
+    model_particle_three = MRC.lrmp_setup(model_particle_three)
+    model_particle_three = MRC.mal_setup_paricle(model_particle_three, case_particle_three)
+    model_particle_three.filename = f"lrmp_{case_particle_three['num_reactions']}_reaction_particle.h5"
+    model_particle_three.save()
+    data_particle_three = model_particle_three.run_simulation()
+    print(data_particle_three.return_code)
+    print(data_particle_three.error_message)
+
+    # compare results
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(model_particle_one.root.output.solution.solution_times, model_particle_one.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 1 Reaction')
+        plt.plot(model_particle_two.root.output.solution.solution_times, model_particle_two.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 2 Reactions')
+        plt.plot(model_particle_three.root.output.solution.solution_times, model_particle_three.root.output.solution.unit_000.solution_bulk[:, 0], label='Particle - 3 Reactions')
+        plt.xlabel('Time')
+        plt.ylabel('Concentration')
+        plt.legend()
+        plt.title('LRMP Multiple Particle Reactions Comparison')
+        #plt.savefig(output_path + '/lrmp_multiple_reactions_particle_comparison.png')
+        plt.show()
+    
+    # print max absolut error
+    max_error_1_2 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_two.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 2 particle reactions: {max_error_1_2}')
+
+    max_error_1_3 = np.max(np.abs(model_particle_one.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 1 and 3 particle reactions: {max_error_1_3}')
+    
+    max_error_2_3 = np.max(np.abs(model_particle_two.root.output.solution.unit_000.solution_bulk - model_particle_three.root.output.solution.unit_000.solution_bulk))
+    print(f'Max absolute error between 2 and 3 particle reactions: {max_error_2_3}')
+
+

--- a/src/verify_cadet-core.py
+++ b/src/verify_cadet-core.py
@@ -35,6 +35,7 @@ import MCT
 import chrom_systems
 import twoDimChromatography
 import chromatography_sensitivities
+import multiple_reactions
 
 #%% User Input
 
@@ -56,6 +57,7 @@ run_chromatography_system_tests = False
 run_crystallization_tests = False
 run_MCT_tests = False
 run_2Dmodels_tests = False
+run_reaction_tests = True
 
 database_path = "https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-database" + \
     "/-/raw/core_tests/cadet_config/test_cadet-core/"
@@ -66,7 +68,6 @@ output_path = project_repo.output_path / "test_cadet-core"
 
 # The get_cadet_path function searches for the cadet-cli. If you want to use a specific source build, please define the path below
 cadet_path = convergence.get_cadet_path() # path to root folder of bin\cadet-cli 
- 
 
 # %% Run with CADET-RDM
 
@@ -153,4 +154,15 @@ with project_repo.track_results(results_commit_message=commit_message, debug=rdm
     
         if delete_h5_files:
             convergence.delete_h5_files(str(output_path) + "/2Dchromatography", exclude_files=exclude_files)
+
+    if run_reaction_tests:
+        multiple_reactions.multiple_reactions_grm_test_bulk(
+            output_path = str(output_path) + "/reaction/multiple_reactions_bulk_grm.h5", cadet_path=cadet_path, plot = True)
+        multiple_reactions.multiple_reactions_lrmp_test_bulk(
+            output_path = str(output_path) + "/reaction/multiple_reactions_bulk_lrmp.h5", cadet_path=cadet_path, plot = True)
+        multiple_reactions.multiple_reactions_mct_test_bulk(
+            output_path = str(output_path) + "/reaction/multiple_reactions_bulk_mct.h5", cadet_path=cadet_path, plot = True)
+
+        if delete_h5_files:
+            convergence.delete_h5_files(str(output_path) + "/reaction", exclude_files=exclude_files)
         


### PR DESCRIPTION
This pull request enhances the `src/verify_cadet-core.py` script by adding functionality to test reaction models and integrating them into the existing workflow. The most important changes include importing a new module, enabling reaction tests, and implementing specific reaction test cases.

### Additions to reaction testing:

* Added the `multiple_reactions` module import to support reaction testing functionality. (`[src/verify_cadet-core.pyR38](diffhunk://#diff-32a96d33bd56851c4b04cc2065f66a8a1fa3ced0921e0f5a4d6d88cb160c44f3R38)`)
* Introduced a new configuration flag, `run_reaction_tests`, set to `True` by default, to enable or disable reaction tests. (`[src/verify_cadet-core.pyR60](diffhunk://#diff-32a96d33bd56851c4b04cc2065f66a8a1fa3ced0921e0f5a4d6d88cb160c44f3R60)`)
* Implemented three new reaction test cases (`multiple_reactions_grm_test_bulk`, `multiple_reactions_lrmp_test_bulk`, and `multiple_reactions_mct_test_bulk`) and integrated them into the workflow. These tests generate output files and optionally delete them after execution. (`[src/verify_cadet-core.pyR158-R168](diffhunk://#diff-32a96d33bd56851c4b04cc2065f66a8a1fa3ced0921e0f5a4d6d88cb160c44f3R158-R168)`)