### PR TITLE
Add manual dispatch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        description: "Docker image to use for the verification job"
+        required: false
+        default: "ghcr.io/cadet/cadet-suite:master"
 
 permissions:
   contents: read
@@ -13,7 +19,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: ghcr.io/cadet/cadet-suite:master
+      DOCKER_IMAGE: ${{ github.event.inputs.docker_image || 'ghcr.io/cadet/cadet-suite:master' }}
       PYTEST_ARGS: ""
     steps:
       - name: Run test in Docker


### PR DESCRIPTION
The CI is sometimes expected to fail since the required image is not always the latest master image. Thus we need a manual dispatch with the option to specify the image name