### PR TITLE
Fix radial flow EOC test: number of particle cells

### DIFF
--- a/src/bench_configs.py
+++ b/src/bench_configs.py
@@ -550,7 +550,7 @@ def radial_flow_benchmark(small_test=False, sensitivities=False):
         'ax_discs': [
             [bench_func.disc_list(8, 11 if not small_test else 3)],
             [bench_func.disc_list(8, 7 if not small_test else 3)],
-            [bench_func.disc_list(8, 6 if not small_test else 3)]
+            [bench_func.disc_list(8, 5 if not small_test else 3)]
         ],
         'par_methods': [
             [None], [None], [0]


### PR DESCRIPTION
This Commit reverts the accidental increase in axial cells (without the corresponding increase in particle cells) for one radial flow EOC test setting, mistake made in 87587729ef4853e5fd1d0f04fa420336210e6a8a